### PR TITLE
Expand dependency detection beyond Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Everything else is automatic — git hooks track commits, dependencies are auto-
 
 ### Auto-everything
 - **Task detection** — from branch name (`feat/user-auth` → "user auth") + recent commits
-- **Dependency tracking** — added Stripe? Auto-logged. Removed Redis? Logged too.
+- **Dependency tracking** — added Stripe? Auto-logged. Removed Redis? Logged too. Works across JS/TS, Python, Go, Rust, and Ruby manifests.
 - **Git hooks** — auto-saves state on every commit
 
 ### Branch-aware state

--- a/src/save.js
+++ b/src/save.js
@@ -208,72 +208,14 @@ function autoDetectTask(projectRoot) {
 }
 
 /**
- * Auto-detect dependency changes by comparing current package.json with saved state.
- * Returns array of decision strings like "added redis (ioredis@^5.0.0)"
+ * Auto-detect dependency changes across supported ecosystems.
+ * Returns array of decision strings like "added Redis (ioredis@^5.0.0)".
  */
 function autoDetectDepChanges(projectRoot, state) {
   const changes = [];
-  const pkgPath = path.join(projectRoot, 'package.json');
-  if (!fs.existsSync(pkgPath)) return changes;
-
-  let pkg;
-  try {
-    pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-  } catch { return changes; }
-
-  const currentDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+  const currentDeps = collectDependencySnapshot(projectRoot);
   const currentDepNames = new Set(Object.keys(currentDeps));
 
-  // Compare with what we know from saved state tech_stack
-  const knownTech = new Set((state.project?.tech_stack || []).map(t => t.toLowerCase()));
-
-  // Check for notable new deps that weren't in the detected stack
-  const notableDeps = {
-    // Databases & ORMs
-    'redis': 'Redis', 'ioredis': 'Redis (ioredis)', 'bullmq': 'BullMQ (Redis)', 'bull': 'Bull (Redis)',
-    'prisma': 'Prisma', '@prisma/client': 'Prisma', 'drizzle-orm': 'Drizzle ORM', 'drizzle-kit': 'Drizzle Kit',
-    'mongoose': 'MongoDB (Mongoose)', 'mongodb': 'MongoDB', 'pg': 'PostgreSQL', 'postgres': 'PostgreSQL',
-    '@neondatabase/serverless': 'Neon PostgreSQL', 'mysql2': 'MySQL', 'mysql': 'MySQL',
-    'better-sqlite3': 'SQLite', 'sql.js': 'SQLite', 'typeorm': 'TypeORM', 'knex': 'Knex',
-    'sequelize': 'Sequelize', '@planetscale/database': 'PlanetScale',
-    // Payments
-    'stripe': 'Stripe', '@stripe/stripe-js': 'Stripe', 'paypal-rest-sdk': 'PayPal', '@paypal/checkout-server-sdk': 'PayPal',
-    'razorpay': 'Razorpay', 'lemon-squeezy': 'Lemon Squeezy',
-    // Auth
-    'next-auth': 'NextAuth', '@auth/core': 'Auth.js', 'passport': 'Passport.js',
-    'lucia': 'Lucia Auth', 'lucia-auth': 'Lucia Auth', '@clerk/nextjs': 'Clerk',
-    'jsonwebtoken': 'JWT', 'jose': 'JWT (jose)', 'bcrypt': 'bcrypt',
-    // BaaS & Cloud
-    'firebase': 'Firebase', 'firebase-admin': 'Firebase Admin',
-    '@supabase/supabase-js': 'Supabase', 'supabase': 'Supabase',
-    'aws-sdk': 'AWS SDK', '@aws-sdk/client-s3': 'AWS S3', '@aws-sdk/client-dynamodb': 'DynamoDB',
-    '@google-cloud/storage': 'GCP Storage', '@azure/storage-blob': 'Azure Blob',
-    // Realtime
-    'socket.io': 'Socket.IO', 'ws': 'WebSockets', 'pusher': 'Pusher', '@pusher/push-notifications-web': 'Pusher',
-    // API & GraphQL
-    'graphql': 'GraphQL', '@apollo/server': 'Apollo GraphQL', '@apollo/client': 'Apollo Client',
-    '@trpc/server': 'tRPC', '@trpc/client': 'tRPC Client',
-    // Monitoring
-    '@sentry/node': 'Sentry', '@sentry/nextjs': 'Sentry', 'newrelic': 'New Relic',
-    'pino': 'Pino Logger', 'winston': 'Winston Logger', 'datadog-metrics': 'Datadog',
-    // AI/ML
-    'openai': 'OpenAI', '@anthropic-ai/sdk': 'Anthropic Claude', 'langchain': 'LangChain',
-    '@huggingface/inference': 'Hugging Face', 'ai': 'Vercel AI SDK', '@ai-sdk/openai': 'Vercel AI SDK',
-    // Email
-    'nodemailer': 'Nodemailer', 'resend': 'Resend', '@sendgrid/mail': 'SendGrid', 'postmark': 'Postmark',
-    // Storage & CDN
-    '@uploadthing/react': 'UploadThing', 'cloudinary': 'Cloudinary', 'sharp': 'Sharp (image processing)',
-    // Frameworks (notable additions mid-project)
-    'next': 'Next.js', 'express': 'Express', 'fastify': 'Fastify', 'hono': 'Hono',
-    '@nestjs/core': 'NestJS', 'remix': 'Remix', 'astro': 'Astro',
-    // Testing
-    'vitest': 'Vitest', 'jest': 'Jest', 'playwright': 'Playwright', '@playwright/test': 'Playwright',
-    'cypress': 'Cypress', 'msw': 'MSW (Mock Service Worker)',
-    // Infra
-    'docker-compose': 'Docker', 'kubernetes-client': 'Kubernetes',
-  };
-
-  // Read previously saved deps (if any)
   const savedDepsPath = path.join(projectRoot, '.mindswap', '.deps-snapshot.json');
   let savedDeps = {};
   try {
@@ -284,26 +226,234 @@ function autoDetectDepChanges(projectRoot, state) {
 
   const savedDepNames = new Set(Object.keys(savedDeps));
 
-  // Detect additions
   for (const dep of currentDepNames) {
-    if (!savedDepNames.has(dep) && notableDeps[dep]) {
-      changes.push(`added ${notableDeps[dep]} (${dep}@${currentDeps[dep]})`);
+    if (!savedDepNames.has(dep) && NOTABLE_DEPS[dep]) {
+      changes.push(`added ${NOTABLE_DEPS[dep]} (${dep}@${currentDeps[dep]})`);
     }
   }
 
-  // Detect removals
   for (const dep of savedDepNames) {
-    if (!currentDepNames.has(dep) && notableDeps[dep]) {
-      changes.push(`removed ${notableDeps[dep]} (${dep})`);
+    if (!currentDepNames.has(dep) && NOTABLE_DEPS[dep]) {
+      changes.push(`removed ${NOTABLE_DEPS[dep]} (${dep})`);
     }
   }
 
-  // Save current snapshot for next comparison
   try {
     fs.writeFileSync(savedDepsPath, JSON.stringify(currentDeps, null, 2), 'utf-8');
   } catch {}
 
   return changes;
+}
+
+const NOTABLE_DEPS = {
+  // JS/TS
+  'redis': 'Redis', 'ioredis': 'Redis (ioredis)', 'bullmq': 'BullMQ (Redis)', 'bull': 'Bull (Redis)',
+  'prisma': 'Prisma', '@prisma/client': 'Prisma', 'drizzle-orm': 'Drizzle ORM', 'drizzle-kit': 'Drizzle Kit',
+  'mongoose': 'MongoDB (Mongoose)', 'mongodb': 'MongoDB', 'pg': 'PostgreSQL', 'postgres': 'PostgreSQL',
+  '@neondatabase/serverless': 'Neon PostgreSQL', 'mysql2': 'MySQL', 'mysql': 'MySQL',
+  'better-sqlite3': 'SQLite', 'sql.js': 'SQLite', 'typeorm': 'TypeORM', 'knex': 'Knex',
+  'sequelize': 'Sequelize', '@planetscale/database': 'PlanetScale',
+  'stripe': 'Stripe', '@stripe/stripe-js': 'Stripe', 'paypal-rest-sdk': 'PayPal', '@paypal/checkout-server-sdk': 'PayPal',
+  'razorpay': 'Razorpay', 'lemon-squeezy': 'Lemon Squeezy',
+  'next-auth': 'NextAuth', '@auth/core': 'Auth.js', 'passport': 'Passport.js',
+  'lucia': 'Lucia Auth', 'lucia-auth': 'Lucia Auth', '@clerk/nextjs': 'Clerk',
+  'jsonwebtoken': 'JWT', 'jose': 'JWT (jose)', 'bcrypt': 'bcrypt',
+  'firebase': 'Firebase', 'firebase-admin': 'Firebase Admin',
+  '@supabase/supabase-js': 'Supabase', 'supabase': 'Supabase',
+  'aws-sdk': 'AWS SDK', '@aws-sdk/client-s3': 'AWS S3', '@aws-sdk/client-dynamodb': 'DynamoDB',
+  '@google-cloud/storage': 'GCP Storage', '@azure/storage-blob': 'Azure Blob',
+  'socket.io': 'Socket.IO', 'ws': 'WebSockets', 'pusher': 'Pusher', '@pusher/push-notifications-web': 'Pusher',
+  'graphql': 'GraphQL', '@apollo/server': 'Apollo GraphQL', '@apollo/client': 'Apollo Client',
+  '@trpc/server': 'tRPC', '@trpc/client': 'tRPC Client',
+  '@sentry/node': 'Sentry', '@sentry/nextjs': 'Sentry', 'newrelic': 'New Relic',
+  'pino': 'Pino Logger', 'winston': 'Winston Logger', 'datadog-metrics': 'Datadog',
+  'openai': 'OpenAI', '@anthropic-ai/sdk': 'Anthropic Claude', 'langchain': 'LangChain',
+  '@huggingface/inference': 'Hugging Face', 'ai': 'Vercel AI SDK', '@ai-sdk/openai': 'Vercel AI SDK',
+  'nodemailer': 'Nodemailer', 'resend': 'Resend', '@sendgrid/mail': 'SendGrid', 'postmark': 'Postmark',
+  '@uploadthing/react': 'UploadThing', 'cloudinary': 'Cloudinary', 'sharp': 'Sharp (image processing)',
+  'next': 'Next.js', 'express': 'Express', 'fastify': 'Fastify', 'hono': 'Hono',
+  '@nestjs/core': 'NestJS', 'remix': 'Remix', 'astro': 'Astro',
+  'vitest': 'Vitest', 'jest': 'Jest', 'playwright': 'Playwright', '@playwright/test': 'Playwright',
+  'cypress': 'Cypress', 'msw': 'MSW (Mock Service Worker)',
+  'docker-compose': 'Docker', 'kubernetes-client': 'Kubernetes',
+  // Python
+  'django': 'Django', 'flask': 'Flask', 'fastapi': 'FastAPI', 'streamlit': 'Streamlit',
+  'sqlalchemy': 'SQLAlchemy', 'psycopg2': 'PostgreSQL (psycopg2)', 'psycopg2-binary': 'PostgreSQL (psycopg2-binary)',
+  'redis-py': 'Redis (redis-py)', 'redis': 'Redis', 'celery': 'Celery', 'uvicorn': 'Uvicorn',
+  'gunicorn': 'Gunicorn', 'pytest': 'Pytest', 'pydantic': 'Pydantic', 'httpx': 'HTTPX',
+  // Go
+  'github.com/gin-gonic/gin': 'Gin', 'github.com/labstack/echo/v4': 'Echo', 'github.com/gofiber/fiber/v2': 'Fiber',
+  'gofr.dev': 'GoFr', 'gorm.io/gorm': 'GORM', 'gorm.io/driver/postgres': 'GORM Postgres',
+  'gorm.io/driver/mysql': 'GORM MySQL', 'gorm.io/driver/sqlite': 'GORM SQLite',
+  'github.com/redis/go-redis/v9': 'Redis (go-redis)', 'github.com/stripe/stripe-go/v78': 'Stripe',
+  'github.com/aws/aws-sdk-go-v2': 'AWS SDK v2',
+  // Rust
+  'actix-web': 'Actix Web', 'axum': 'Axum', 'rocket': 'Rocket', 'tokio': 'Tokio',
+  'sqlx': 'SQLx', 'diesel': 'Diesel', 'serde': 'Serde', 'reqwest': 'Reqwest',
+  'redis-rs': 'Redis (redis-rs)', 'redis': 'Redis', 'sea-orm': 'SeaORM',
+  // Ruby
+  'rails': 'Rails', 'sinatra': 'Sinatra', 'sidekiq': 'Sidekiq', 'pg': 'PostgreSQL',
+  'mysql2': 'MySQL', 'redis': 'Redis', 'devise': 'Devise', 'puma': 'Puma',
+};
+
+function collectDependencySnapshot(projectRoot) {
+  const snapshot = {};
+  mergeInto(snapshot, parsePackageJsonDeps(projectRoot));
+  mergeInto(snapshot, parseRequirementsDeps(projectRoot));
+  mergeInto(snapshot, parsePyprojectDeps(projectRoot));
+  mergeInto(snapshot, parseGoModDeps(projectRoot));
+  mergeInto(snapshot, parseCargoDeps(projectRoot));
+  mergeInto(snapshot, parseGemfileDeps(projectRoot));
+  return snapshot;
+}
+
+function mergeInto(target, source) {
+  for (const [name, version] of Object.entries(source)) {
+    target[name] = version;
+  }
+}
+
+function parsePackageJsonDeps(projectRoot) {
+  const pkgPath = path.join(projectRoot, 'package.json');
+  if (!fs.existsSync(pkgPath)) return {};
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    return { ...pkg.dependencies, ...pkg.devDependencies };
+  } catch {
+    return {};
+  }
+}
+
+function parseRequirementsDeps(projectRoot) {
+  const files = ['requirements.txt', 'Pipfile.lock', 'poetry.lock'];
+  const deps = {};
+
+  const reqPath = path.join(projectRoot, 'requirements.txt');
+  if (fs.existsSync(reqPath)) {
+    const content = fs.readFileSync(reqPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('-')) continue;
+      const match = trimmed.match(/^([A-Za-z0-9_.-]+)\s*(?:==|>=|<=|~=|!=|>|<)?\s*([^;\s]+)?/);
+      if (match) deps[match[1].toLowerCase()] = match[2] || 'unknown';
+    }
+  }
+
+  const pipfileLockPath = path.join(projectRoot, 'Pipfile.lock');
+  if (fs.existsSync(pipfileLockPath)) {
+    try {
+      const lock = JSON.parse(fs.readFileSync(pipfileLockPath, 'utf-8'));
+      for (const section of ['default', 'develop']) {
+        for (const [name, info] of Object.entries(lock[section] || {})) {
+          deps[name.toLowerCase()] = typeof info === 'string' ? info : info.version || 'unknown';
+        }
+      }
+    } catch {}
+  }
+
+  return deps;
+}
+
+function parsePyprojectDeps(projectRoot) {
+  const pyprojectPath = path.join(projectRoot, 'pyproject.toml');
+  if (!fs.existsSync(pyprojectPath)) return {};
+  const deps = {};
+  const content = fs.readFileSync(pyprojectPath, 'utf-8');
+
+  const patterns = [
+    /dependencies\s*=\s*\[([\s\S]*?)\]/m,
+    /dev-dependencies\s*=\s*\[([\s\S]*?)\]/m,
+  ];
+  for (const pattern of patterns) {
+    const match = content.match(pattern);
+    if (!match) continue;
+    const entries = match[1].split('\n').map(line => line.trim()).filter(Boolean);
+    for (const entry of entries) {
+      const depMatch = entry.match(/"?([A-Za-z0-9_.-]+)[^"]*"?/);
+      if (depMatch) {
+        const name = depMatch[1].toLowerCase();
+        const versionMatch = entry.match(/([0-9][A-Za-z0-9.+-]*)/);
+        deps[name] = versionMatch ? versionMatch[1] : 'unknown';
+      }
+    }
+  }
+
+  const poetrySectionMatch = content.match(/\[tool\.poetry\.dependencies\]([\s\S]*?)(?:\n\[|$)/m);
+  if (poetrySectionMatch) {
+    for (const line of poetrySectionMatch[1].split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('python')) continue;
+      const match = trimmed.match(/^([A-Za-z0-9_.-]+)\s*=\s*["']?([^"']+)["']?/);
+      if (match) deps[match[1].toLowerCase()] = match[2];
+    }
+  }
+
+  return deps;
+}
+
+function parseGoModDeps(projectRoot) {
+  const goModPath = path.join(projectRoot, 'go.mod');
+  if (!fs.existsSync(goModPath)) return {};
+  const deps = {};
+  const content = fs.readFileSync(goModPath, 'utf-8');
+  const requireBlockMatch = content.match(/require\s*\(([\s\S]*?)\)/m);
+  if (requireBlockMatch) {
+    for (const line of requireBlockMatch[1].split('\n')) {
+      const trimmed = line.trim();
+      const match = trimmed.match(/^([^\s]+)\s+([^\s]+)/);
+      if (match) deps[match[1]] = match[2];
+    }
+  }
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    const match = trimmed.match(/^require\s+([^\s]+)\s+([^\s]+)/);
+    if (match) deps[match[1]] = match[2];
+  }
+  return deps;
+}
+
+function parseCargoDeps(projectRoot) {
+  const cargoPath = path.join(projectRoot, 'Cargo.toml');
+  if (!fs.existsSync(cargoPath)) return {};
+  const deps = {};
+  const content = fs.readFileSync(cargoPath, 'utf-8');
+  const sections = new Set(['dependencies', 'dev-dependencies', 'build-dependencies']);
+  let currentSection = null;
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (sectionMatch) {
+      currentSection = sections.has(sectionMatch[1]) ? sectionMatch[1] : null;
+      continue;
+    }
+
+    if (!currentSection) continue;
+
+    const depMatch = trimmed.match(/^([A-Za-z0-9_.-]+)\s*=\s*(.+)$/);
+    if (!depMatch) continue;
+    const name = depMatch[1];
+    const versionMatch = depMatch[2].match(/["']([^"']+)["']/);
+    deps[name] = versionMatch ? versionMatch[1] : depMatch[2].trim();
+  }
+
+  return deps;
+}
+
+function parseGemfileDeps(projectRoot) {
+  const gemfilePath = path.join(projectRoot, 'Gemfile');
+  if (!fs.existsSync(gemfilePath)) return {};
+  const deps = {};
+  const content = fs.readFileSync(gemfilePath, 'utf-8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const match = trimmed.match(/^gem\s+['"]([^'"]+)['"](?:,\s*['"]([^'"]+)['"])?/);
+    if (match) deps[match[1]] = match[2] || 'unknown';
+  }
+  return deps;
 }
 
 /**

--- a/test/save.test.js
+++ b/test/save.test.js
@@ -51,6 +51,50 @@ exports.test_autoDetectDepChanges_no_changes = () => {
   } finally { teardown(); }
 };
 
+exports.test_autoDetectDepChanges_python_requirements = () => {
+  setup();
+  try {
+    fs.writeFileSync(path.join(dir, 'requirements.txt'), 'fastapi==0.111.0\nredis==5.0.1\n');
+    const state = { project: { tech_stack: ['python'] } };
+    const changes = saveModule.autoDetectDepChanges(dir, state);
+    assert.ok(changes.some(change => change.includes('FastAPI')), `expected FastAPI change, got ${changes.join(', ')}`);
+    assert.ok(changes.some(change => change.includes('Redis')), `expected Redis change, got ${changes.join(', ')}`);
+  } finally { teardown(); }
+};
+
+exports.test_autoDetectDepChanges_go_mod = () => {
+  setup();
+  try {
+    fs.writeFileSync(path.join(dir, 'go.mod'), `module example.com/test\n\ngo 1.22\n\nrequire (\n\tgithub.com/gin-gonic/gin v1.10.0\n\tgithub.com/redis/go-redis/v9 v9.5.1\n)\n`);
+    const state = { project: { tech_stack: ['go'] } };
+    const changes = saveModule.autoDetectDepChanges(dir, state);
+    assert.ok(changes.some(change => change.includes('Gin')), `expected Gin change, got ${changes.join(', ')}`);
+    assert.ok(changes.some(change => change.includes('Redis')), `expected Redis change, got ${changes.join(', ')}`);
+  } finally { teardown(); }
+};
+
+exports.test_autoDetectDepChanges_cargo = () => {
+  setup();
+  try {
+    fs.writeFileSync(path.join(dir, 'Cargo.toml'), `[package]\nname = "test"\nversion = "0.1.0"\n\n[dependencies]\naxum = "0.7"\nredis = "0.25"\n`);
+    const state = { project: { tech_stack: ['rust'] } };
+    const changes = saveModule.autoDetectDepChanges(dir, state);
+    assert.ok(changes.some(change => change.includes('Axum')), `expected Axum change, got ${changes.join(', ')}`);
+    assert.ok(changes.some(change => change.includes('Redis')), `expected Redis change, got ${changes.join(', ')}`);
+  } finally { teardown(); }
+};
+
+exports.test_autoDetectDepChanges_gemfile = () => {
+  setup();
+  try {
+    fs.writeFileSync(path.join(dir, 'Gemfile'), `source "https://rubygems.org"\ngem "rails", "~> 7.1"\ngem "sidekiq", "~> 7.2"\n`);
+    const state = { project: { tech_stack: ['ruby'] } };
+    const changes = saveModule.autoDetectDepChanges(dir, state);
+    assert.ok(changes.some(change => change.includes('Rails')), `expected Rails change, got ${changes.join(', ')}`);
+    assert.ok(changes.some(change => change.includes('Sidekiq')), `expected Sidekiq change, got ${changes.join(', ')}`);
+  } finally { teardown(); }
+};
+
 exports.test_autoDetectWorkSummary_with_commits = () => {
   setup();
   try {


### PR DESCRIPTION
## Summary
- expand dependency snapshotting and auto-detection beyond `package.json`
- support Python, Go, Rust, and Ruby manifests in the save flow
- add regression coverage and README updates for broader ecosystem support

## Testing
- `npm test`
- temp Python repo: `save` auto-logs FastAPI and Redis from `requirements.txt`
- temp Go repo: helper detects Gin and go-redis from `go.mod`
- temp Rust repo: helper detects Axum and Redis from `Cargo.toml`
- temp Ruby repo: helper detects Rails and Sidekiq from `Gemfile`

Closes #5
