### PR TITLE
Improve session parsing with a normalized cross-tool session model

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Everything else is automatic — git hooks track commits, dependencies are auto-
 ### Branch-aware state
 Each git branch has its own state. Switch to `feat/payments` — it loads that branch's task and decisions. Switch back to `main` — your main state is restored.
 
+### Native session normalization
+mindswap reads recent Claude Code and Codex session files, normalizes them into a structured model, and surfaces the last session's findings, blockers, and edited files in `HANDOFF.md` and MCP context.
+
 ### Decision conflict detection
 Log "NOT using Redis" then later "using Redis"? mindswap warns you. Also catches reversed choices and package.json contradictions.
 
@@ -136,7 +139,7 @@ npx mindswap mcp-install   # auto-configures Claude Code, Cursor, VS Code
 
 | MCP Tool | When AI calls it | What it returns |
 |----------|-----------------|-----------------|
-| `mindswap_get_context` | Session start — "What do I need to know?" | Synthesized briefing: task, decisions, conflicts, tests, recent work |
+| `mindswap_get_context` | Session start — "What do I need to know?" | Synthesized briefing: task, decisions, conflicts, tests, recent work, native session findings |
 | `mindswap_save_context` | Session end — "Here's what I did" | Persists summary, decisions, next steps, blockers |
 | `mindswap_search` | Mid-session — "What did we decide about auth?" | Searches decisions + history + state |
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -6,6 +6,7 @@ const { isGitRepo, getCurrentBranch, getAllChangedFiles, getDiffSummary, getDiff
 const { buildNarrative, buildCompactNarrative, summarizeFiles } = require('./narrative');
 const { scanAndRedact, printSecretWarnings } = require('./secrets');
 const { detectMonorepo, getMonorepoSection, detectChangedPackages } = require('./monorepo');
+const { parseNativeSessions, getSessionSummary } = require('./session-parser');
 
 const SECTION_START = '<!-- mindswap:start -->';
 const SECTION_END = '<!-- mindswap:end -->';
@@ -176,6 +177,7 @@ function gatherLiveData(projectRoot) {
       .slice(-10);
   }
   data.history = getHistory(projectRoot, 5);
+  data.nativeSessions = parseNativeSessions(projectRoot);
   return data;
 }
 
@@ -255,6 +257,13 @@ ${live.branch ? `- **Git branch**: ${live.branch}` : ''}
     md += `\n## Session history (recent)\n`;
     for (const h of live.history) {
       md += `- **${h.timestamp}**: ${h.message}${h.ai_tool ? ` (${h.ai_tool})` : ''}\n`;
+    }
+  }
+
+  if (live.nativeSessions?.length > 0) {
+    const sessionSummary = getSessionSummary(live.nativeSessions);
+    if (sessionSummary.trim()) {
+      md += `${sessionSummary}\n`;
     }
   }
 

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -10,6 +10,7 @@ const { buildNarrative, buildCompactNarrative, calculateQualityScore } = require
 const { findAllConflicts, checkDepsVsDecisions } = require('./conflicts');
 const { detectAITool } = require('./detect-ai');
 const { detectMonorepo, getMonorepoSection, detectChangedPackages } = require('./monorepo');
+const { parseNativeSessions, getSessionSummary } = require('./session-parser');
 
 /**
  * Start the mindswap MCP server.
@@ -167,6 +168,13 @@ function getContext(projectRoot, focus, compact) {
     // Changed files (grouped)
     if (liveData.changedFiles.length > 0) {
       sections.push(`## Uncommitted Changes\n${liveData.changedFiles.length} files changed`);
+    }
+  }
+
+  if (liveData.nativeSessions?.length > 0) {
+    const sessionSummary = getSessionSummary(liveData.nativeSessions);
+    if (sessionSummary.trim()) {
+      sections.push(sessionSummary.trim());
     }
   }
 
@@ -360,6 +368,7 @@ function gatherLiveData(projectRoot) {
     recentCommits: [],
     decisions: [],
     history: [],
+    nativeSessions: [],
   };
 
   if (isGitRepo(projectRoot)) {
@@ -376,6 +385,7 @@ function gatherLiveData(projectRoot) {
   }
 
   data.history = getHistory(projectRoot, 5);
+  data.nativeSessions = parseNativeSessions(projectRoot);
   return data;
 }
 

--- a/src/narrative.js
+++ b/src/narrative.js
@@ -48,6 +48,12 @@ function buildNarrative(state, liveData) {
     parts.push(workDone);
   }
 
+  // ─── Recent native AI session ───
+  const sessionBrief = describeSessionFindings(liveData.nativeSessions);
+  if (sessionBrief) {
+    parts.push(sessionBrief);
+  }
+
   // ─── Test/build status ───
   if (state.test_status) {
     const ts = state.test_status;
@@ -113,6 +119,11 @@ function buildCompactNarrative(state, liveData) {
   // Recent commits (just messages, no hashes)
   if (liveData.recentCommits?.length > 0) {
     lines.push(`RECENT: ${liveData.recentCommits.slice(0, 3).map(c => c.message).join(' | ')}`);
+  }
+
+  const sessionBrief = describeSessionFindings(liveData.nativeSessions);
+  if (sessionBrief) {
+    lines.push(`SESSION: ${sessionBrief}`);
   }
 
   // Decisions (stripped, semicolon-separated)
@@ -242,6 +253,22 @@ function summarizeFiles(changedFiles) {
   return `${total} uncommitted files (${parts.join(', ')}${areaStr}).`;
 }
 
+function describeSessionFindings(sessions) {
+  if (!sessions || sessions.length === 0) return null;
+
+  const session = sessions[0];
+  const parts = [];
+  parts.push(`${session.tool}${session.timestamp ? ` @ ${session.timestamp}` : ''}`);
+  if (session.summary) parts.push(session.summary);
+  if (session.blockers?.length > 0) parts.push(`blocker: ${session.blockers[0]}`);
+  if (session.failures?.length > 0) parts.push(`failure: ${session.failures[0]}`);
+  if (session.fileEdits?.length > 0) {
+    parts.push(`files: ${session.fileEdits.slice(0, 3).map(f => path.basename(f)).join(', ')}`);
+  }
+
+  return parts.join(' — ');
+}
+
 /**
  * Calculate context quality score (0-100).
  * Tells user how complete their handoff context is.
@@ -308,6 +335,7 @@ module.exports = {
   buildNarrative,
   buildCompactNarrative,
   describeWorkDone,
+  describeSessionFindings,
   detectWorkPatterns,
   calculateQualityScore,
   summarizeFiles,

--- a/src/save.js
+++ b/src/save.js
@@ -7,7 +7,7 @@ const { detectAITool } = require('./detect-ai');
 const { detectLastStatus, runChecks } = require('./build-test');
 const { generate } = require('./generate');
 const { calculateQualityScore } = require('./narrative');
-const { parseNativeSessions } = require('./session-parser');
+const { parseNativeSessions, getSessionSummary } = require('./session-parser');
 
 /**
  * THE one command. Auto-detects everything, saves full state, generates all context files.
@@ -94,10 +94,9 @@ async function save(projectRoot, opts = {}) {
   try {
     const sessions = parseNativeSessions(projectRoot);
     if (sessions.length > 0 && !quiet) {
-      for (const s of sessions) {
-        if (s.fileEdits?.length > 0) {
-          console.log(chalk.dim(`  ${s.tool}:   `) + chalk.white(`${s.fileEdits.length} files edited in last session`));
-        }
+      const sessionSummary = getSessionSummary(sessions);
+      for (const line of sessionSummary.split('\n').filter(Boolean).slice(0, 10)) {
+        console.log(chalk.dim('  ') + chalk.white(line.trim()));
       }
     }
   } catch (err) {

--- a/src/session-parser.js
+++ b/src/session-parser.js
@@ -2,194 +2,535 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
+const MAX_FILES = 20;
+const MAX_COMMANDS = 10;
+const MAX_MESSAGES = 8;
+const MAX_SESSION_FILES = 8;
+
 /**
- * Parse native AI tool session files for rich context.
- * Reads actual conversation/session data from tool-specific formats.
+ * Parse native AI tool sessions into a normalized model.
+ * Returns the most relevant recent sessions for the current project.
  */
 function parseNativeSessions(projectRoot) {
   const sessions = [];
 
-  const claude = parseClaudeCodeSessions(projectRoot);
-  if (claude) sessions.push(claude);
+  sessions.push(...parseClaudeCodeSessions(projectRoot));
+  sessions.push(...parseCodexSessions(projectRoot));
 
-  const codex = parseCodexSessions(projectRoot);
-  if (codex) sessions.push(codex);
+  return sessions
+    .filter(session => session && session.projectMatch?.score > 0)
+    .sort((a, b) => {
+      const scoreDiff = (b.projectMatch?.score || 0) - (a.projectMatch?.score || 0);
+      if (scoreDiff !== 0) return scoreDiff;
+      return (b.timestamp || '').localeCompare(a.timestamp || '');
+    })
+    .slice(0, 4);
+}
+
+/**
+ * Parse Claude Code session data from ~/.claude/projects/.
+ */
+function parseClaudeCodeSessions(projectRoot) {
+  const claudeBase = path.join(os.homedir(), '.claude');
+  const projectsDir = path.join(claudeBase, 'projects');
+  if (!fs.existsSync(projectsDir)) return [];
+
+  const sessions = [];
+  for (const projectDirName of safeReaddir(projectsDir)) {
+    const projectDir = path.join(projectsDir, projectDirName);
+    if (!isDirectory(projectDir)) continue;
+
+    const sessionFiles = safeReaddir(projectDir)
+      .filter(f => f.endsWith('.jsonl'))
+      .sort((a, b) => fileMtime(path.join(projectDir, b)) - fileMtime(path.join(projectDir, a)))
+      .slice(0, MAX_SESSION_FILES);
+
+    for (const sessionFile of sessionFiles) {
+      const sourceFile = path.join(projectDir, sessionFile);
+      const parsed = parseClaudeSessionFile(projectRoot, sourceFile, projectDirName);
+      if (parsed) sessions.push(parsed);
+    }
+  }
+
+  return sessions;
+}
+
+function parseClaudeSessionFile(projectRoot, sourceFile, projectDirName) {
+  const content = readText(sourceFile);
+  if (!content) return null;
+
+  const entries = content
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .slice(-5000)
+    .map(line => safeJsonParse(line))
+    .filter(Boolean);
+
+  if (entries.length === 0) return null;
+  return normalizeSession({
+    tool: 'Claude Code',
+    sourceFile,
+    projectRoot,
+    sourceLabel: projectDirName,
+    entries,
+    rawText: content,
+    modifiedAt: fileMtime(sourceFile),
+  });
+}
+
+/**
+ * Parse OpenAI Codex CLI sessions from ~/.codex/sessions/.
+ */
+function parseCodexSessions(projectRoot) {
+  const codexDir = path.join(os.homedir(), '.codex', 'sessions');
+  if (!fs.existsSync(codexDir)) return [];
+
+  const sessions = [];
+  const sessionFiles = safeReaddir(codexDir)
+    .filter(f => f.endsWith('.json'))
+    .sort((a, b) => fileMtime(path.join(codexDir, b)) - fileMtime(path.join(codexDir, a)))
+    .slice(0, MAX_SESSION_FILES);
+
+  for (const sessionFile of sessionFiles) {
+    const sourceFile = path.join(codexDir, sessionFile);
+    const content = readText(sourceFile);
+    if (!content) continue;
+
+    const session = safeJsonParse(content);
+    if (!session) continue;
+
+    const entries = [];
+    if (Array.isArray(session.messages)) {
+      for (const message of session.messages) {
+        entries.push(message);
+      }
+    }
+    if (Array.isArray(session.events)) {
+      for (const event of session.events) {
+        entries.push(event);
+      }
+    }
+    if (Array.isArray(session.transcript)) {
+      for (const item of session.transcript) {
+        entries.push(item);
+      }
+    }
+    if (entries.length === 0) {
+      entries.push(session);
+    }
+
+    const normalized = normalizeSession({
+      tool: 'Codex',
+      sourceFile,
+      projectRoot,
+      sourceLabel: sessionFile,
+      entries,
+      rawText: content,
+      modifiedAt: fileMtime(sourceFile),
+    });
+
+    if (normalized) sessions.push(normalized);
+  }
 
   return sessions;
 }
 
 /**
- * Parse Claude Code session data.
- * Claude Code stores sessions in ~/.claude/projects/<hash>/
- * Each session is a JSONL file with messages.
+ * Normalize a raw session file into a structured record.
  */
-function parseClaudeCodeSessions(projectRoot) {
-  const claudeBase = path.join(os.homedir(), '.claude');
-  if (!fs.existsSync(claudeBase)) return null;
+function normalizeSession({ tool, sourceFile, projectRoot, sourceLabel, entries, rawText, modifiedAt }) {
+  const messages = [];
+  const fileEdits = [];
+  const toolCalls = [];
+  const blockers = [];
+  const failures = [];
+  const snippets = [];
+  let timestamp = null;
 
-  const projectsDir = path.join(claudeBase, 'projects');
-  if (!fs.existsSync(projectsDir)) return null;
+  for (const entry of entries) {
+    if (!entry) continue;
 
-  // Find the project directory matching our project root
-  // Claude uses sanitized paths as directory names
-  const sanitizedRoot = projectRoot.replace(/\//g, '-').replace(/^-/, '');
-  const projectDirs = safeReaddir(projectsDir);
+    if (typeof entry === 'string') {
+      const text = entry.trim();
+      if (text) {
+        messages.push({ role: 'unknown', text });
+        snippets.push(text);
+        if (looksBlocked(text)) blockers.push(firstSentence(text));
+        if (looksFailed(text)) failures.push(firstSentence(text));
+      }
+      continue;
+    }
 
-  let sessionDir = null;
-  for (const dir of projectDirs) {
-    if (dir.includes(sanitizedRoot) || dir.includes(path.basename(projectRoot))) {
-      sessionDir = path.join(projectsDir, dir);
-      break;
+    if (typeof entry !== 'object') continue;
+
+    const entryTime = extractTimestamp(entry);
+    if (entryTime && (!timestamp || entryTime > timestamp)) timestamp = entryTime;
+
+    const entryText = extractEntryText(entry);
+    if (entryText) snippets.push(entryText);
+
+    const messageText = extractMessageText(entry);
+    if (messageText) {
+      const role = typeof entry.role === 'string'
+        ? entry.role
+        : typeof entry.type === 'string'
+          ? entry.type
+          : 'unknown';
+      messages.push({ role, text: messageText });
+      if (looksBlocked(messageText)) blockers.push(firstSentence(messageText));
+      if (looksFailed(messageText)) failures.push(firstSentence(messageText));
+    }
+
+    const extractedFiles = extractFileEdits(entry);
+    for (const file of extractedFiles) {
+      fileEdits.push(file);
+      snippets.push(file);
+    }
+
+    const extractedCommands = extractToolCalls(entry);
+    for (const cmd of extractedCommands) {
+      toolCalls.push(cmd);
+      snippets.push(cmd);
     }
   }
 
-  if (!sessionDir) return null;
+  if (!timestamp) timestamp = modifiedAt || null;
 
-  const result = {
-    tool: 'Claude Code',
-    lastSession: null,
-    fileEdits: [],
-    toolCalls: [],
-    messages: [],
-    summary: null,
-  };
+  const uniqueFiles = uniqueStrings(fileEdits).slice(0, MAX_FILES);
+  const uniqueCommands = uniqueStrings(toolCalls).slice(0, MAX_COMMANDS);
+  const uniqueMessages = dedupeMessages(messages).slice(-MAX_MESSAGES);
+  const uniqueBlockers = uniqueStrings(blockers).slice(0, 5);
+  const uniqueFailures = uniqueStrings(failures).slice(0, 5);
 
-  // Read session JSONL files
-  const sessionFiles = safeReaddir(sessionDir)
-    .filter(f => f.endsWith('.jsonl'))
-    .sort()
-    .reverse(); // Most recent first
+  const score = scoreProjectMatch({
+    projectRoot,
+    sourceFile,
+    sourceLabel,
+    rawText,
+    snippets,
+    fileEdits: uniqueFiles,
+    toolCalls: uniqueCommands,
+    messages: uniqueMessages,
+  });
 
-  if (sessionFiles.length === 0) return null;
-
-  // Parse the most recent session
-  const latestSession = path.join(sessionDir, sessionFiles[0]);
-  try {
-    const content = fs.readFileSync(latestSession, 'utf-8');
-    const lines = content.split('\n').filter(l => l.trim()).slice(-5000); // Limit to last 5000 lines
-
-    for (const line of lines) {
-      try {
-        const entry = JSON.parse(line);
-
-        // Extract assistant messages (summarize what was done)
-        if (entry.role === 'assistant' && entry.content) {
-          const text = typeof entry.content === 'string' ? entry.content :
-            Array.isArray(entry.content) ? entry.content.filter(c => c.type === 'text').map(c => c.text).join(' ') : '';
-          if (text.length > 20 && text.length < 500) {
-            result.messages.push(text.slice(0, 300));
-          }
-        }
-
-        // Extract tool use (file edits, commands run)
-        if (entry.role === 'assistant' && Array.isArray(entry.content)) {
-          for (const block of entry.content) {
-            if (block.type === 'tool_use') {
-              if (block.name === 'Edit' || block.name === 'Write') {
-                result.fileEdits.push(block.input?.file_path || 'unknown file');
-              }
-              if (block.name === 'Bash') {
-                const cmd = (block.input?.command || '').slice(0, 100);
-                if (cmd && !cmd.includes('password') && !cmd.includes('secret')) {
-                  result.toolCalls.push(cmd);
-                }
-              }
-            }
-          }
-        }
-      } catch {}
-    }
-
-    // Deduplicate
-    result.fileEdits = [...new Set(result.fileEdits)].slice(0, 20);
-    result.toolCalls = [...new Set(result.toolCalls)].slice(0, 10);
-    result.messages = result.messages.slice(-5);
-    result.lastSession = sessionFiles[0];
-
-  } catch {}
-
-  return result.fileEdits.length > 0 || result.messages.length > 0 ? result : null;
-}
-
-/**
- * Parse OpenAI Codex CLI session data.
- * Codex stores sessions in ~/.codex/sessions/ as JSON files.
- */
-function parseCodexSessions(projectRoot) {
-  const codexDir = path.join(os.homedir(), '.codex', 'sessions');
-  if (!fs.existsSync(codexDir)) return null;
-
-  const result = {
-    tool: 'Codex',
-    lastSession: null,
-    fileEdits: [],
-    toolCalls: [],
-    messages: [],
-  };
-
-  const sessionFiles = safeReaddir(codexDir)
-    .filter(f => f.endsWith('.json'))
-    .sort()
-    .reverse();
-
-  if (sessionFiles.length === 0) return null;
-
-  // Parse most recent session
-  try {
-    const content = fs.readFileSync(path.join(codexDir, sessionFiles[0]), 'utf-8');
-    const session = JSON.parse(content);
-
-    if (Array.isArray(session.messages)) {
-      for (const msg of session.messages) {
-        if (msg.role === 'assistant' && typeof msg.content === 'string') {
-          if (msg.content.length > 20 && msg.content.length < 500) {
-            result.messages.push(msg.content.slice(0, 300));
-          }
-        }
-      }
-    }
-
-    result.lastSession = sessionFiles[0];
-    result.messages = result.messages.slice(-5);
-  } catch {}
-
-  return result.messages.length > 0 ? result : null;
-}
-
-/**
- * Get a summary of native session data for HANDOFF.md.
- */
-function getSessionSummary(sessions) {
-  if (sessions.length === 0) return '';
-
-  const lines = [];
-  lines.push('\n## Recent AI sessions\n');
-
-  for (const session of sessions) {
-    lines.push(`### ${session.tool}`);
-
-    if (session.fileEdits?.length > 0) {
-      lines.push(`Files edited: ${session.fileEdits.slice(0, 10).map(f => `\`${path.basename(f)}\``).join(', ')}`);
-    }
-
-    if (session.toolCalls?.length > 0) {
-      lines.push(`Commands run: ${session.toolCalls.slice(0, 5).map(c => `\`${c.slice(0, 60)}\``).join(', ')}`);
-    }
-
-    if (session.messages?.length > 0) {
-      lines.push(`Last actions:`);
-      for (const msg of session.messages.slice(-3)) {
-        // Extract first sentence
-        const firstSentence = msg.split(/[.!?\n]/)[0].trim();
-        if (firstSentence.length > 10) {
-          lines.push(`- ${firstSentence}`);
-        }
-      }
-    }
-    lines.push('');
+  if (score.score <= 0 && uniqueFiles.length === 0 && uniqueCommands.length === 0 && uniqueMessages.length === 0) {
+    return null;
   }
 
-  return lines.join('\n');
+  return {
+    tool,
+    sourceFile,
+    sourceLabel,
+    timestamp,
+    projectMatch: score,
+    status: uniqueBlockers.length > 0 || uniqueFailures.length > 0 ? 'blocked' : 'active',
+    summary: buildSessionSummary(uniqueMessages, uniqueFiles, uniqueCommands, uniqueBlockers, uniqueFailures),
+    fileEdits: uniqueFiles,
+    toolCalls: uniqueCommands,
+    messages: uniqueMessages,
+    blockers: uniqueBlockers,
+    failures: uniqueFailures,
+  };
+}
+
+function buildSessionSummary(messages, fileEdits, toolCalls, blockers, failures) {
+  const opener = messages.find(m => m.role === 'assistant' && m.text)?.text
+    || messages.find(m => m.text)?.text
+    || '';
+  if (opener) {
+    const trimmed = firstSentence(opener);
+    if (trimmed) return trimmed;
+  }
+
+  if (blockers.length > 0) {
+    return `Blocked: ${blockers[0]}`;
+  }
+
+  if (failures.length > 0) {
+    return `Failed: ${failures[0]}`;
+  }
+
+  if (fileEdits.length > 0) {
+    const sample = fileEdits.slice(0, 3).map(f => `\`${path.basename(f)}\``).join(', ');
+    return `Edited ${sample}`;
+  }
+
+  if (toolCalls.length > 0) {
+    const sample = toolCalls.slice(0, 2).map(c => `\`${c.slice(0, 40)}\``).join(', ');
+    return `Ran ${sample}`;
+  }
+
+  return '';
+}
+
+function scoreProjectMatch({ projectRoot, sourceFile, sourceLabel, rawText, snippets, fileEdits, toolCalls, messages }) {
+  const projectName = path.basename(projectRoot).toLowerCase();
+  const normalizedRoot = normalizePath(projectRoot);
+
+  let score = 0;
+  const signals = [];
+  const haystacks = [
+    normalizePath(rawText),
+    normalizePath(sourceFile),
+    normalizePath(sourceLabel),
+    ...snippets.map(normalizePath),
+    ...fileEdits.map(normalizePath),
+    ...toolCalls.map(normalizePath),
+    ...messages.map(m => normalizePath(m.text || '')),
+  ].filter(Boolean);
+
+  if (normalizePath(sourceFile).includes(normalizedRoot)) {
+    score += 40;
+    signals.push('path match');
+  }
+
+  if (normalizePath(sourceLabel).includes(projectName)) {
+    score += 20;
+    signals.push('project dir match');
+  }
+
+  if (haystacks.some(text => text.includes(normalizedRoot))) {
+    score += 45;
+    signals.push('project path mentioned');
+  }
+
+  if (haystacks.some(text => text.includes(projectName))) {
+    score += 15;
+    signals.push('project name mentioned');
+  }
+
+  const projectFiles = fileEdits.filter(file => isProjectPath(file, projectRoot));
+  if (projectFiles.length > 0) {
+    score += Math.min(30, projectFiles.length * 10);
+    signals.push(`${projectFiles.length} file(s) in project`);
+  }
+
+  const commandHits = toolCalls.filter(cmd => isProjectPath(cmd, projectRoot));
+  if (commandHits.length > 0) {
+    score += Math.min(20, commandHits.length * 5);
+    signals.push(`${commandHits.length} command(s) in project`);
+  }
+
+  return {
+    score,
+    matched: score > 0,
+    signals: uniqueStrings(signals).slice(0, 8),
+  };
+}
+
+function extractTimestamp(entry) {
+  const candidates = [
+    entry.timestamp,
+    entry.created_at,
+    entry.createdAt,
+    entry.time,
+    entry.ts,
+    entry.date,
+    entry.updated_at,
+    entry.updatedAt,
+  ];
+  for (const candidate of candidates) {
+    const parsed = parseDate(candidate);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+function extractEntryText(entry) {
+  const parts = [];
+
+  const push = value => {
+    if (typeof value === 'string' && value.trim()) parts.push(value.trim());
+  };
+
+  push(entry.text);
+  push(entry.message);
+  push(entry.content);
+  push(entry.command);
+  push(entry.output);
+  push(entry.result);
+  push(entry.summary);
+
+  if (Array.isArray(entry.content)) {
+    for (const block of entry.content) {
+      if (!block || typeof block !== 'object') continue;
+      push(block.text);
+      push(block.content);
+      push(block.command);
+      push(block.input?.command);
+      push(block.input?.text);
+      push(block.input?.file_path);
+      push(block.input?.path);
+      push(block.input?.new_string);
+      push(block.input?.old_string);
+      push(block.input?.files);
+    }
+  }
+
+  if (Array.isArray(entry.messages)) {
+    for (const message of entry.messages) {
+      push(extractMessageText(message));
+    }
+  }
+
+  return uniqueStrings(parts).join(' ');
+}
+
+function extractMessageText(entry) {
+  if (!entry || typeof entry !== 'object') return '';
+
+  if (typeof entry.content === 'string') return entry.content.trim();
+  if (Array.isArray(entry.content)) {
+    const textParts = [];
+    for (const block of entry.content) {
+      if (!block || typeof block !== 'object') continue;
+      if (block.type === 'text' && typeof block.text === 'string') {
+        textParts.push(block.text.trim());
+      } else if (block.type === 'tool_use') {
+        continue;
+      } else if (typeof block.text === 'string') {
+        textParts.push(block.text.trim());
+      }
+    }
+    return textParts.join(' ').trim();
+  }
+
+  if (typeof entry.message === 'string') return entry.message.trim();
+  if (typeof entry.text === 'string') return entry.text.trim();
+  if (typeof entry.output === 'string') return entry.output.trim();
+  if (typeof entry.summary === 'string') return entry.summary.trim();
+  return '';
+}
+
+function extractFileEdits(entry) {
+  const edits = [];
+
+  const scanInput = input => {
+    if (!input || typeof input !== 'object') return;
+    const paths = [
+      input.file_path,
+      input.path,
+      input.file,
+      input.filename,
+      input.target_file,
+      input.targetFile,
+      input.files,
+      input.paths,
+    ];
+    for (const value of paths) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (typeof item === 'string') edits.push(item.trim());
+        }
+      } else if (typeof value === 'string') {
+        edits.push(value.trim());
+      }
+    }
+  };
+
+  if (Array.isArray(entry.content)) {
+    for (const block of entry.content) {
+      if (!block || typeof block !== 'object') continue;
+      if (block.type === 'tool_use' || block.type === 'tool') {
+        if (['Edit', 'Write', 'MultiEdit', 'Replace', 'Patch'].includes(block.name)) {
+          scanInput(block.input);
+        }
+      }
+    }
+  }
+
+  scanInput(entry);
+  return uniqueStrings(edits);
+}
+
+function extractToolCalls(entry) {
+  const commands = [];
+
+  const pushCommand = value => {
+    if (typeof value !== 'string') return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    if (trimmed.length > 240) {
+      commands.push(trimmed.slice(0, 240));
+    } else {
+      commands.push(trimmed);
+    }
+  };
+
+  if (Array.isArray(entry.content)) {
+    for (const block of entry.content) {
+      if (!block || typeof block !== 'object') continue;
+      if (block.type === 'tool_use' || block.type === 'tool') {
+        if (block.name === 'Bash' || block.name === 'Shell' || block.name === 'Terminal') {
+          pushCommand(block.input?.command || block.input?.text || block.text);
+        }
+      }
+    }
+  }
+
+  pushCommand(entry.command);
+  pushCommand(entry.input?.command);
+  pushCommand(entry.input?.text);
+  pushCommand(entry.shell);
+
+  return uniqueStrings(commands);
+}
+
+function looksBlocked(text) {
+  return /\b(blocked|blocker|stuck|waiting on|can't continue|cannot continue|need .* before|hold up)\b/i.test(text);
+}
+
+function looksFailed(text) {
+  return /\b(fail|failed|error|exception|traceback|crash|broken|cannot run)\b/i.test(text);
+}
+
+function firstSentence(text) {
+  return String(text || '')
+    .replace(/\s+/g, ' ')
+    .split(/[.!?\n]/)[0]
+    .trim();
+}
+
+function normalizePath(value) {
+  return String(value || '').toLowerCase().replace(/\\/g, '/');
+}
+
+function isProjectPath(value, projectRoot) {
+  const normalized = normalizePath(value);
+  const root = normalizePath(projectRoot);
+  const base = path.basename(projectRoot).toLowerCase();
+  return normalized.includes(root) || normalized.includes(`/${base}/`) || normalized.endsWith(`/${base}`);
+}
+
+function parseDate(value) {
+  if (!value) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  if (typeof value === 'string') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  return null;
+}
+
+function fileMtime(filePath) {
+  try {
+    return new Date(fs.statSync(filePath).mtimeMs).toISOString();
+  } catch {
+    return null;
+  }
+}
+
+function readText(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return '';
+  }
 }
 
 function safeReaddir(dir) {
@@ -200,4 +541,93 @@ function safeReaddir(dir) {
   }
 }
 
-module.exports = { parseNativeSessions, getSessionSummary, parseClaudeCodeSessions };
+function isDirectory(filePath) {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function safeJsonParse(content) {
+  try {
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+function uniqueStrings(values) {
+  return [...new Set((values || []).map(value => String(value || '').trim()).filter(Boolean))];
+}
+
+function dedupeMessages(messages) {
+  const seen = new Set();
+  const result = [];
+  for (const message of messages || []) {
+    if (!message || !message.text) continue;
+    const key = `${message.role || 'unknown'}::${message.text}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push({ role: message.role || 'unknown', text: message.text });
+  }
+  return result;
+}
+
+/**
+ * Get a summary of native session data for HANDOFF.md and MCP context.
+ */
+function getSessionSummary(sessions) {
+  if (!sessions || sessions.length === 0) return '';
+
+  const lines = [];
+  lines.push('\n## Recent AI sessions\n');
+
+  for (const session of sessions) {
+    const relevance = session.projectMatch?.score != null ? `${session.projectMatch.score}/100` : 'n/a';
+    const timestamp = session.timestamp ? ` @ ${session.timestamp}` : '';
+    lines.push(`### ${session.tool}${timestamp}`);
+    lines.push(`Relevance: ${relevance}`);
+
+    if (session.summary) {
+      lines.push(`Summary: ${session.summary}`);
+    }
+
+    if (session.fileEdits?.length > 0) {
+      lines.push(`Files edited: ${session.fileEdits.slice(0, 10).map(f => `\`${path.basename(f)}\``).join(', ')}`);
+    }
+
+    if (session.toolCalls?.length > 0) {
+      lines.push(`Commands run: ${session.toolCalls.slice(0, 5).map(c => `\`${c.slice(0, 60)}\``).join(', ')}`);
+    }
+
+    if (session.blockers?.length > 0) {
+      lines.push(`Blocker: ${session.blockers[0]}`);
+    }
+
+    if (session.failures?.length > 0) {
+      lines.push(`Failure: ${session.failures[0]}`);
+    }
+
+    if (session.messages?.length > 0) {
+      lines.push('Last actions:');
+      for (const message of session.messages.slice(-3)) {
+        const first = firstSentence(message.text);
+        if (first.length > 10) {
+          lines.push(`- ${first}`);
+        }
+      }
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+module.exports = {
+  parseNativeSessions,
+  getSessionSummary,
+  parseClaudeCodeSessions,
+  parseCodexSessions,
+  normalizeSession,
+};

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { createTempProject, cleanup } = require('./helpers');
 const { ensureDataDir, writeState, getDefaultState } = require('../src/state');
 const { generate, safeWriteContextFile, SECTION_START, SECTION_END } = require('../src/generate');
@@ -24,6 +25,16 @@ function setup() {
     '# Decisions\n\n[2026-01-01T00:00:00Z] [auth] chose JWT over sessions\n', 'utf-8');
 }
 function teardown() { cleanup(dir); }
+
+function withFakeHome(homeDir, fn) {
+  const original = os.homedir;
+  os.homedir = () => homeDir;
+  try {
+    return fn();
+  } finally {
+    os.homedir = original;
+  }
+}
 
 exports.test_generate_creates_handoff_md = async () => {
   setup();
@@ -107,4 +118,29 @@ exports.test_generate_claude_does_not_overwrite_existing = async () => {
     assert.ok(content.includes('Never use var'));
     assert.ok(content.includes(SECTION_START));
   } finally { teardown(); }
+};
+
+exports.test_generate_includes_native_session_summary = async () => {
+  setup();
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mindswap-home-'));
+  try {
+    const sessionPath = path.join(homeDir, '.claude', 'projects', 'match-1', 'session.jsonl');
+    fs.mkdirSync(path.dirname(sessionPath), { recursive: true });
+    fs.writeFileSync(sessionPath, [
+      JSON.stringify({ role: 'assistant', content: [{ type: 'text', text: 'Blocked on database migration.' }] }),
+      JSON.stringify({ role: 'assistant', content: [{ type: 'tool_use', name: 'Edit', input: { file_path: path.join(dir, 'src', 'index.js') } }] }),
+    ].join('\n'), 'utf-8');
+
+    console.log = () => {};
+    await withFakeHome(homeDir, () => generate(dir, { handoff: true }));
+    console.log = global.console.log;
+
+    const handoff = fs.readFileSync(path.join(dir, 'HANDOFF.md'), 'utf-8');
+    assert.ok(handoff.includes('Recent AI sessions'));
+    assert.ok(handoff.includes('Blocked on database migration'));
+  } finally {
+    console.log = global.console.log;
+    teardown();
+    cleanup(homeDir);
+  }
 };

--- a/test/session-parser.test.js
+++ b/test/session-parser.test.js
@@ -1,0 +1,90 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createTempProject, cleanup } = require('./helpers');
+const { parseNativeSessions, getSessionSummary } = require('../src/session-parser');
+
+function withFakeHome(homeDir, fn) {
+  const original = os.homedir;
+  os.homedir = () => homeDir;
+  try {
+    return fn();
+  } finally {
+    os.homedir = original;
+  }
+}
+
+function writeJsonl(filePath, entries) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, entries.map(entry => JSON.stringify(entry)).join('\n'), 'utf-8');
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+exports.test_parseNativeSessions_normalizes_claude_sessions = () => {
+  const projectRoot = createTempProject('session-parser-claude');
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mindswap-home-'));
+
+  try {
+    const relevantFile = path.join(homeDir, '.claude', 'projects', 'match-1', 'session.jsonl');
+    writeJsonl(relevantFile, [
+      { role: 'assistant', content: [{ type: 'text', text: 'Blocked on API key for the billing flow.' }] },
+      { role: 'assistant', content: [{ type: 'tool_use', name: 'Edit', input: { file_path: path.join(projectRoot, 'src', 'server.js') } }] },
+      { role: 'assistant', content: [{ type: 'tool_use', name: 'Bash', input: { command: `cd ${projectRoot} && npm test` } }] },
+    ]);
+
+    writeJsonl(path.join(homeDir, '.claude', 'projects', 'unrelated', 'session.jsonl'), [
+      { role: 'assistant', content: [{ type: 'text', text: 'Unrelated notes for another repo.' }] },
+    ]);
+
+    withFakeHome(homeDir, () => {
+      const sessions = parseNativeSessions(projectRoot);
+      assert.strictEqual(sessions.length, 1);
+      assert.strictEqual(sessions[0].tool, 'Claude Code');
+      assert.ok(sessions[0].projectMatch.score > 0);
+      assert.ok(sessions[0].summary.includes('Blocked on API key'));
+      assert.ok(sessions[0].blockers[0].includes('Blocked on API key'));
+      assert.ok(sessions[0].fileEdits[0].endsWith(path.join('src', 'server.js')));
+
+      const summary = getSessionSummary(sessions);
+      assert.ok(summary.includes('Recent AI sessions'));
+      assert.ok(summary.includes('Blocker: Blocked on API key'));
+      assert.ok(summary.includes('Commands run:'));
+    });
+  } finally {
+    cleanup(projectRoot);
+    cleanup(homeDir);
+  }
+};
+
+exports.test_parseNativeSessions_normalizes_codex_sessions = () => {
+  const projectRoot = createTempProject('session-parser-codex');
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mindswap-home-'));
+
+  try {
+    const sessionPath = path.join(homeDir, '.codex', 'sessions', '2026-04-23-session.json');
+    writeJson(sessionPath, {
+      messages: [
+        { role: 'assistant', content: `Investigating ${projectRoot} and fixing the parser.` },
+        { role: 'assistant', content: 'Command: cd ' + projectRoot + ' && cargo test' },
+      ],
+    });
+
+    withFakeHome(homeDir, () => {
+      const sessions = parseNativeSessions(projectRoot);
+      assert.strictEqual(sessions.length, 1);
+      assert.strictEqual(sessions[0].tool, 'Codex');
+      assert.ok(sessions[0].projectMatch.score > 0);
+      assert.ok(sessions[0].summary.includes('Investigating'));
+      assert.ok(sessions[0].messages.length > 0);
+      assert.ok(getSessionSummary(sessions).includes('Codex'));
+    });
+  } finally {
+    cleanup(projectRoot);
+    cleanup(homeDir);
+  }
+};


### PR DESCRIPTION
Summary: normalize Claude Code and Codex session parsing into structured session records, score project relevance, and surface the latest session findings in generated handoff and MCP context.\n\nChanges: added normalized native session parsing, project-match scoring, session summaries, README docs, and regression tests for Claude, Codex, and handoff generation.\n\nValidation: npm test -> 109 passed, 0 failed. Also ran an initialized temp-repo smoke test with a fake Claude session fixture and verified parseNativeSessions returns normalized data and HANDOFF.md includes recent session findings.