### PR TITLE
Refine MCP performance and add scoped memory indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/mindswap.svg)](https://www.npmjs.com/package/mindswap)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Keep project context in the repo so AI tools can continue work without re-explaining the same codebase.
+Keep project context and personal AI memory local so tools can continue work without re-explaining the same context.
 
 ## Why it exists
 
@@ -33,8 +33,26 @@ npx mindswap ask "Why did we choose JWT?"
 - `resume` to start with a clean briefing
 - `ask` to search project memory with citations
 - `memory` to manage blockers, assumptions, questions, and resolutions
+- `--global` memory and ask scope for personal cross-tool memory under `~/.mindswap/`
+- `reindex` to rebuild the local SQLite search index from your file-based memory
 - `sync` to share continuity state across machines
 - `mcp` and `mcp-http` to expose the same context to AI clients
+
+## Global personal memory
+
+MindSwap now supports two local memory scopes:
+
+- repo memory in `<repo>/.mindswap/`
+- personal memory in `~/.mindswap/`
+
+Use global memory when a preference or learning should follow you across projects and tools.
+
+```bash
+npx mindswap log "Prefer concise explanations" --type assumption --global
+npx mindswap memory list --scope all
+npx mindswap ask "What explanation style should we use?" --scope all
+npx mindswap reindex --scope all
+```
 
 ## MCP and AI tools
 

--- a/bin/mindswap.js
+++ b/bin/mindswap.js
@@ -22,6 +22,7 @@ const { save } = require('../src/save');
 const { pr } = require('../src/pr');
 const { doctor } = require('../src/doctor');
 const { buildRegistryReport, readRegistryManifest, writeRegistryManifest } = require('../src/registry');
+const { reindex } = require('../src/reindex');
 
 const program = new Command();
 
@@ -96,6 +97,8 @@ program
   .description('Log a memory item. Decisions warn on conflicts; blockers/questions/assumptions/resolutions are stored in structured memory.')
   .option('--tag <tag>', 'Tag (e.g., architecture, database, auth)')
   .option('--type <type>', 'Memory type: decision, blocker, assumption, question, resolution')
+  .option('--global', 'Write to global personal memory')
+  .option('--scope <scope>', 'Memory scope: repo or global')
   .action(async (message, opts) => {
     try {
       await log(process.cwd(), message, opts);
@@ -118,6 +121,8 @@ program
   .option('--after <iso>', 'Created after timestamp')
   .option('--before <iso>', 'Created before timestamp')
   .option('--hard', 'Permanently delete instead of archiving')
+  .option('--global', 'Use global personal memory scope')
+  .option('--scope <scope>', 'Memory scope: repo, global, all')
   .option('--json', 'Output as JSON')
   .action(async (action, id, messageParts, opts) => {
     try {
@@ -137,6 +142,8 @@ program
         created_after: opts.after,
         created_before: opts.before,
         hard: opts.hard,
+        global: opts.global,
+        scope: opts.scope,
         json: opts.json,
       });
       if (result?.content?.length) {
@@ -313,6 +320,8 @@ program
 program
   .command('ask <question...>')
   .description('Answer a question from project memory using semantic search and cited sources.')
+  .option('--global', 'Search global personal memory')
+  .option('--scope <scope>', 'Search scope: repo, global, all')
   .option('--json', 'Output as JSON')
   .action(async (question, opts) => {
     try {
@@ -364,6 +373,22 @@ program
   .action(async (opts) => {
     try {
       await resume(process.cwd(), opts);
+    } catch (err) {
+      console.error(chalk.red('Error:'), err.message);
+      process.exit(1);
+    }
+  });
+
+// ─── reindex ───
+program
+  .command('reindex')
+  .description('Rebuild the local SQLite search index from repo and/or global memory.')
+  .option('--global', 'Reindex global personal memory only')
+  .option('--scope <scope>', 'Reindex scope: repo, global, all')
+  .option('--json', 'Output as JSON')
+  .action(async (opts) => {
+    try {
+      await reindex(process.cwd(), opts);
     } catch (err) {
       console.error(chalk.red('Error:'), err.message);
       process.exit(1);

--- a/bin/mindswap.js
+++ b/bin/mindswap.js
@@ -17,7 +17,7 @@ const { resume } = require('../src/resume');
 const { ask } = require('../src/ask');
 const { contracts } = require('../src/contracts');
 const { sync } = require('../src/sync');
-const { manageMemory, startMCPServer, startMCPHttpServer } = require('../src/mcp-server');
+const { manageMemory, searchContext, startMCPServer, startMCPHttpServer } = require('../src/mcp-server');
 const { save } = require('../src/save');
 const { pr } = require('../src/pr');
 const { doctor } = require('../src/doctor');
@@ -317,6 +317,37 @@ program
   });
 
 // ─── ask ───
+program
+  .command('search <query...>')
+  .description('Raw search over project memory, history, decisions, and optional global memory.')
+  .option('--type <type>', 'Search type: all, decisions, history', 'all')
+  .option('--global', 'Search global personal memory')
+  .option('--scope <scope>', 'Search scope: repo, global, all')
+  .option('--json', 'Output as JSON')
+  .action(async (queryParts, opts) => {
+    try {
+      const query = Array.isArray(queryParts) ? queryParts.join(' ').trim() : String(queryParts || '').trim();
+      const result = searchContext(process.cwd(), query, opts.type || 'all', null, {
+        global: opts.global,
+        scope: opts.scope,
+      });
+      const text = result?.content?.[0]?.text || '';
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify({
+          query,
+          type: opts.type || 'all',
+          scope: opts.scope || (opts.global ? 'global' : 'repo'),
+          text,
+        }, null, 2)}\n`);
+        return;
+      }
+      process.stdout.write(`${text}\n`);
+    } catch (err) {
+      console.error(chalk.red('Error:'), err.message);
+      process.exit(1);
+    }
+  });
+
 program
   .command('ask <question...>')
   .description('Answer a question from project memory using semantic search and cited sources.')
@@ -642,9 +673,11 @@ async function installMCP() {
   }
 
   console.log(chalk.bold.green(`\n✓ MCP server configured for ${configured} tool${configured > 1 ? 's' : ''}!\n`));
-  console.log(chalk.dim('  3 tools available to AI:'));
+  console.log(chalk.dim('  4 tools available to AI:'));
   console.log(chalk.white('    mindswap_get_context  ') + chalk.dim('— "What do I need to know?"'));
   console.log(chalk.white('    mindswap_save_context ') + chalk.dim('— "Here\'s what I did"'));
   console.log(chalk.white('    mindswap_search       ') + chalk.dim('— "What did we decide about X?"'));
+  console.log(chalk.white('    mindswap_memory       ') + chalk.dim('— "Track blockers/questions/assumptions"'));
+  console.log(chalk.dim('  Stable resources and workflow prompts are also exposed when supported by the client.'));
   console.log(chalk.dim('\n  Restart your AI tool to activate.\n'));
 }

--- a/docs/issue-drafts.md
+++ b/docs/issue-drafts.md
@@ -1,0 +1,411 @@
+# mindswap issue drafts
+
+## 1. Add `mindswap doctor` for setup and context health checks
+
+**Title:** Add `mindswap doctor` command for setup, context quality, and continuity diagnostics
+
+**Body:**
+
+## Summary
+
+Add a new `mindswap doctor` command that actively validates the current project setup and context quality instead of only reporting passive quality signals.
+
+## Problem
+
+`mindswap` already computes a context quality score and has several implicit expectations:
+
+- `.mindswap` should be initialized
+- git hooks may be installed
+- generated context files may be stale
+- decisions may conflict
+- build/test info may be missing
+- AI tool context files may be missing or out of sync
+
+Today, the product can report some of these signals indirectly, but there is no single diagnostic command that tells the user what is wrong and how to fix it.
+
+## Proposed solution
+
+Add `mindswap doctor` with checks such as:
+
+- `mindswap` initialized or not
+- required files present in `.mindswap/`
+- active branch state available
+- generated files exist and are fresh relative to state/checkpoints
+- git hook installed and healthy
+- decision conflicts detected
+- dependency vs decision conflicts detected
+- test/build status missing or stale
+- MCP install/config status for supported tools
+- context quality breakdown with actionable fixes
+
+## Output shape
+
+- Human-readable mode by default
+- `--json` mode for automation
+- Exit code non-zero when serious issues are found
+
+## Why this matters
+
+This raises trust in the product and gives users a concrete way to debug why continuity is weak in a given repo.
+
+## Likely implementation areas
+
+- `src/narrative.js`
+- `src/state.js`
+- `src/conflicts.js`
+- `src/generate.js`
+- `bin/mindswap.js`
+- new `src/doctor.js`
+
+## Acceptance criteria
+
+- `npx mindswap doctor` prints a grouped report of issues/warnings/ok checks
+- `npx mindswap doctor --json` returns structured machine-readable results
+- detects stale or missing generated context files
+- detects missing hooks and weak context coverage
+- covered by tests
+
+## 2. Introduce structured memory beyond decisions.log
+
+**Title:** Introduce structured memory model for blockers, assumptions, open questions, and resolutions
+
+**Body:**
+
+## Summary
+
+Expand mindswap from an append-only decision log into a structured project memory system.
+
+## Problem
+
+Current memory is strong for checkpoint/history and basic decision logging, but several critical continuity signals are still semi-structured or implicit:
+
+- blockers
+- assumptions
+- unresolved questions
+- next steps
+- resolved decisions
+- abandoned approaches
+
+These are the exact kinds of things a new AI session needs most, and today they are either buried in free text or not represented explicitly enough.
+
+## Proposed solution
+
+Add a structured memory schema, likely under `.mindswap/`, for categories like:
+
+- `decisions`
+- `blockers`
+- `assumptions`
+- `questions`
+- `next_steps`
+- `resolved_items`
+
+This can either supplement or gradually replace `decisions.log`.
+
+## UX ideas
+
+- `mindswap log --type decision`
+- `mindswap log --type blocker`
+- `mindswap log --type assumption`
+- automatic carry-forward of unresolved items into generated handoff context
+
+## MCP impact
+
+This should improve:
+
+- `mindswap_get_context`
+- `mindswap_save_context`
+- `mindswap_search`
+
+because these tools would be able to return clearer, more composable context.
+
+## Why this matters
+
+This is a core product upgrade, not just a data-model cleanup. It makes the continuity layer more trustworthy and more useful for real in-progress work.
+
+## Acceptance criteria
+
+- new structured memory format added under `.mindswap/`
+- CLI supports writing and reading multiple memory types
+- generated context surfaces unresolved blockers/questions distinctly
+- MCP responses expose structured memory cleanly
+- migration path exists for current `decisions.log`
+
+## 3. Add `mindswap resume` for start-of-session briefing
+
+**Title:** Add `mindswap resume` command to generate a start-of-session action briefing
+
+**Body:**
+
+## Summary
+
+Add a dedicated `resume` command that tells the next AI or developer what to do first, not just what the current state is.
+
+## Problem
+
+`HANDOFF.md` and MCP context provide useful state, but there is a missing product layer between “raw state” and “actionable resumption”.
+
+What users often need at session start:
+
+- what changed since last meaningful checkpoint
+- what remains incomplete
+- what is likely broken
+- which blockers are active
+- what the first next step should be
+
+## Proposed solution
+
+Add `mindswap resume` that synthesizes:
+
+- session recap
+- changes since last checkpoint/commit
+- unresolved blockers/questions
+- likely next action
+- optional “recommended first commands to run”
+
+## Possible flags
+
+- `--compact`
+- `--json`
+- `--since <checkpoint|commit|time>`
+
+## Why this matters
+
+This creates a much sharper “pick up where I left off” experience than static handoff text alone.
+
+## Acceptance criteria
+
+- `npx mindswap resume` prints a concise action-oriented briefing
+- uses current task, history, changes, and test/build status
+- clearly distinguishes state from recommendation
+- available through MCP or easily reusable by MCP tools later
+
+## 4. Expand dependency and change detection beyond Node.js
+
+**Title:** Expand dependency/change detection to Python, Go, Rust, and Ruby ecosystems
+
+**Body:**
+
+## Summary
+
+Generalize automatic dependency/change detection so `mindswap` works consistently across non-Node projects.
+
+## Problem
+
+Project detection already supports several ecosystems, but automatic dependency-change logging is still heavily centered around `package.json`.
+
+That creates a mismatch:
+
+- detection says we support multiple stacks
+- continuity depth is much stronger in JS/TS repos than elsewhere
+
+## Proposed solution
+
+Add dependency/change detection support for:
+
+- Python: `requirements.txt`, `pyproject.toml`, `Pipfile.lock`, `poetry.lock`
+- Go: `go.mod`
+- Rust: `Cargo.toml`, `Cargo.lock`
+- Ruby: `Gemfile`, `Gemfile.lock`
+- optionally Java/Kotlin later: `pom.xml`, `build.gradle`, `build.gradle.kts`
+
+## Behavior
+
+When packages/libraries are added or removed, auto-log notable shifts as memory/decisions just like current Node-oriented behavior.
+
+## Why this matters
+
+This is required if mindswap wants to be genuinely language-agnostic instead of primarily optimized for JS repos.
+
+## Acceptance criteria
+
+- dependency-change detection works in at least Python, Go, Rust, and Ruby repos
+- notable packages map to meaningful technology labels
+- no noisy false positives on unchanged repos
+- tests added for each supported ecosystem
+
+## 5. Improve native session parsing and normalization
+
+**Title:** Improve session parsing with a normalized cross-tool session model
+
+**Body:**
+
+## Summary
+
+Upgrade native session parsing from tool-specific shallow extraction into a normalized session understanding layer.
+
+## Problem
+
+Current session parsing/import is a good start, but has important limitations:
+
+- latest-session bias
+- weak project matching heuristics
+- limited tool coverage
+- mostly extracts messages and file edits
+- does not consistently extract intent, failures, blockers, or unfinished work
+
+## Proposed solution
+
+Create a normalized session schema that can represent:
+
+- session timestamp and tool
+- files touched
+- commands run
+- decisions made
+- failures encountered
+- blockers discovered
+- unfinished tasks
+- summary of accomplished work
+
+Then have each tool parser map into that schema.
+
+## Initial scope
+
+- improve Claude Code parser
+- improve Codex parser
+- make it easy to plug in Cursor / other tools later
+
+## Why this matters
+
+This would materially improve handoff quality without requiring more manual user input.
+
+## Acceptance criteria
+
+- normalized session model introduced
+- parsers emit structured session output
+- project matching is more reliable
+- generated context can surface “last session findings” cleanly
+- tests added for parser edge cases
+
+## 6. Upgrade `mindswap_search` from keyword search to semantic memory retrieval
+
+**Title:** Upgrade `mindswap_search` to support semantic retrieval over project memory and history
+
+**Body:**
+
+## Summary
+
+Make `mindswap_search` meaningfully useful for AI agents by moving beyond simple keyword matching.
+
+## Problem
+
+Searching project continuity data is one of the highest-value MCP actions, but plain text matching will not scale well as memory/history grows.
+
+Users and agents need answers to questions like:
+
+- “why did we choose this auth approach?”
+- “what happened last time we touched payments?”
+- “what blockers were found during the last failing test run?”
+
+These queries are often semantic, not exact string matches.
+
+## Proposed solution
+
+Upgrade search to retrieve across:
+
+- structured memory
+- decisions/history
+- recent checkpoints
+- commit messages
+- changed files
+- optionally PR context
+
+Possible path:
+
+- short term: ranked lexical retrieval with better indexing
+- later: optional embeddings-based semantic retrieval
+
+## Why this matters
+
+This directly improves the MCP story and makes mindswap more than a file generator.
+
+## Acceptance criteria
+
+- improved search ranking over current memory/history
+- supports filters by source/type/time
+- surfaces short synthesized answers with citations/links back to source items
+- works both in CLI and MCP
+
+## 7. Add team/shared mode for multi-developer continuity
+
+**Title:** Add team mode for shared project memory, author attribution, and collaborative handoff
+
+**Body:**
+
+## Summary
+
+Extend mindswap from single-user session continuity to collaborative team continuity.
+
+## Problem
+
+The current model is strongest for one developer switching between AI tools on one machine. There is no first-class concept of:
+
+- authorship
+- shared team memory
+- per-branch human handoff
+- coordination between multiple contributors
+
+## Proposed solution
+
+Add an optional team mode with capabilities such as:
+
+- author attribution on checkpoints and memory items
+- shared handoff conventions suitable for committed project memory
+- better branch handoff summaries for PRs/reviews
+- distinction between local-only and team-shared context
+
+## Design concerns
+
+- avoid polluting local flows for solo users
+- preserve simple default UX
+- make committed/shared memory explicit
+
+## Why this matters
+
+This would make mindswap useful for teams, not just individual AI-tool users.
+
+## Acceptance criteria
+
+- author field supported in relevant state/history entries
+- shared vs local memory boundaries are explicit
+- generated handoff can include author-aware recent work
+- docs explain solo vs team workflows
+
+## 8. Deepen IDE / tool integration and auto-hooks
+
+**Title:** Deepen IDE integration with automatic session start/end hooks for supported AI tools
+
+**Body:**
+
+## Summary
+
+Move from passive file generation toward deeper tool integration using automatic hooks where possible.
+
+## Problem
+
+Today, mindswap’s UX still depends heavily on the user remembering to run commands like `mindswap`, `switch`, or `gen`. That is good for an MVP, but weak for sticky daily use.
+
+## Proposed solution
+
+Explore integration paths for supported tools so mindswap can:
+
+- refresh context at session start
+- save context at session end
+- update handoff after meaningful changes
+- register MCP automatically where supported
+
+## Example areas
+
+- better Claude/Cursor/Codex integration
+- stronger MCP install/config flows
+- optional auto-save hooks on branch switch / task completion / commit boundaries
+
+## Why this matters
+
+Reducing manual friction is one of the highest-leverage ways to increase retention and daily value.
+
+## Acceptance criteria
+
+- at least one deeper automatic workflow added for a supported tool
+- hook/install state visible to the user
+- fallback remains safe and explicit when automation is not available
+

--- a/docs/local-first-roadmap.md
+++ b/docs/local-first-roadmap.md
@@ -1,0 +1,128 @@
+# MindSwap Local-First Roadmap
+
+## Product Direction
+
+MindSwap's primary goal is to preserve and share useful context between AI tools.
+
+The product should optimize for:
+
+- local ownership of memory
+- open-source distribution
+- cross-tool continuity
+- zero required cloud services
+- strong developer workflows first
+- room for broader personal AI memory later
+
+MindSwap is not a hosted SaaS in this roadmap. It is a local-first memory layer with repo memory and global personal memory.
+
+## Core Model
+
+MindSwap has two first-class memory scopes:
+
+- `global personal memory`
+  - personal preferences
+  - reusable learnings
+  - cross-tool facts
+  - long-term context not tied to one repo
+- `repo memory`
+  - project state
+  - task progress
+  - decisions
+  - blockers
+  - repo-scoped conventions
+
+Repo memory remains the strongest coding workflow wedge. Global memory becomes the persistent identity and cross-tool continuity layer.
+
+## Storage Model
+
+Human-readable files remain part of the product promise:
+
+- `~/.mindswap/`
+- `<repo>/.mindswap/`
+- `HANDOFF.md`
+- `AGENTS.md`
+- `CODEX.md`
+- other generated tool files
+
+SQLite is used as a local intelligence layer, not a cloud dependency:
+
+- no hosted database
+- no user accounts
+- no remote billing or auth
+- no recurring infrastructure cost
+
+## What MindSwap Should Not Build Right Now
+
+Do not prioritize:
+
+- Supabase or hosted Postgres
+- user login/logout/whoami
+- Stripe billing
+- cloud sync
+- hosted dashboard
+- org workspaces backed by a server
+
+These add product cost and complexity without strengthening the main continuity loop enough.
+
+## Near-Term Product Roadmap
+
+### Phase 1: Global Personal Memory
+
+Ship first-class global memory for use outside repos and across tools.
+
+Targets:
+
+- global memory storage under `~/.mindswap/`
+- CLI support for global memory CRUD
+- scoped search across global, repo, or both
+- scoped `ask` support
+- personal preferences and reusable learnings as first-class memory types
+
+### Phase 2: Local Search Engine
+
+Add a local indexing layer to make recall fast and scalable.
+
+Targets:
+
+- local SQLite index
+- reindex command
+- ranking over global and repo memories
+- related-memory lookup
+- dedupe foundations
+
+### Phase 3: Smarter Continuity
+
+Targets:
+
+- stronger `resume`
+- better "what changed since last session"
+- better unresolved item surfacing
+- better conflict and drift analysis
+- improved imported/native session normalization
+
+### Phase 4: Shared Local Workflows
+
+Targets:
+
+- clearer solo vs shared memory boundaries
+- better team attribution in committed memory
+- git-friendly shared continuity workflows
+- stronger cross-tool handoff prompts and exports
+
+## User Promise
+
+MindSwap should let users say:
+
+- "My AI context stays on my machine."
+- "I can carry memory across tools without a cloud account."
+- "I can inspect my memory in plain files."
+- "I can search both personal and project memory from one tool."
+
+## Immediate Execution Priority
+
+Build in this order:
+
+1. global personal memory
+2. scoped recall across global and repo memory
+3. local indexing layer
+4. smarter continuity features on top of those two scopes

--- a/docs/superpowers/plans/2026-05-01-global-personal-memory.md
+++ b/docs/superpowers/plans/2026-05-01-global-personal-memory.md
@@ -1,0 +1,289 @@
+# Global Personal Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-class global personal memory and scoped recall on top of the current repo-centered MindSwap CLI and MCP memory model.
+
+**Architecture:** Reuse the existing file-based memory format and introduce a small scope-resolution layer that can target repo memory, global memory, or both. Keep repo defaults stable, add explicit global writes, and extend ask/search with cross-scope reads before introducing any local indexing layer.
+
+**Tech Stack:** Node.js, Commander CLI, JSON file storage, existing memory/state/search modules, Node test runner in `test/run.js`
+
+---
+
+### Task 1: Add scope resolution helpers
+
+**Files:**
+- Create: `src/scope.js`
+- Test: `test/scope.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+const assert = require('assert');
+const os = require('os');
+const path = require('path');
+const { createTempProject, cleanup } = require('./helpers');
+const { resolveMemoryRoots, getGlobalProjectRoot } = require('../src/scope');
+
+let dir;
+
+exports.beforeEach = () => {
+  dir = createTempProject('scope-test');
+};
+
+exports.afterEach = () => {
+  cleanup(dir);
+};
+
+exports.test_getGlobalProjectRoot_uses_home_directory = () => {
+  assert.strictEqual(getGlobalProjectRoot(), os.homedir());
+};
+
+exports.test_resolveMemoryRoots_returns_repo_root_by_default_inside_repo = () => {
+  const roots = resolveMemoryRoots(dir, { scope: 'repo' });
+  assert.deepStrictEqual(roots, [dir]);
+};
+
+exports.test_resolveMemoryRoots_supports_global_scope = () => {
+  const roots = resolveMemoryRoots(dir, { scope: 'global' });
+  assert.deepStrictEqual(roots, [os.homedir()]);
+};
+
+exports.test_resolveMemoryRoots_supports_all_scope = () => {
+  const roots = resolveMemoryRoots(dir, { scope: 'all' });
+  assert.deepStrictEqual(roots, [dir, os.homedir()]);
+};
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node test/run.js scope`
+Expected: FAIL with module or function not found errors for `../src/scope`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+const os = require('os');
+
+function getGlobalProjectRoot() {
+  return os.homedir();
+}
+
+function resolveMemoryRoots(projectRoot, opts = {}) {
+  const scope = opts.scope || 'repo';
+  if (scope === 'global') return [getGlobalProjectRoot()];
+  if (scope === 'all') return [projectRoot, getGlobalProjectRoot()];
+  return [projectRoot];
+}
+
+module.exports = {
+  getGlobalProjectRoot,
+  resolveMemoryRoots,
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node test/run.js scope`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/scope.js test/scope.test.js
+git commit -m "feat: add memory scope resolution helpers"
+```
+
+### Task 2: Add global-scoped memory CRUD
+
+**Files:**
+- Modify: `src/memory.js`
+- Modify: `src/mcp-server.js`
+- Modify: `bin/mindswap.js`
+- Test: `test/memory-global.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createTempProject, cleanup } = require('./helpers');
+const { manageMemory } = require('../src/mcp-server');
+const { readMemory } = require('../src/memory');
+
+let dir;
+let globalMemoryPath;
+
+exports.beforeEach = () => {
+  dir = createTempProject('memory-global-test');
+  globalMemoryPath = path.join(os.homedir(), '.mindswap', 'memory.json');
+  try { fs.rmSync(path.join(os.homedir(), '.mindswap'), { recursive: true, force: true }); } catch {}
+};
+
+exports.afterEach = () => {
+  cleanup(dir);
+  try { fs.rmSync(path.join(os.homedir(), '.mindswap'), { recursive: true, force: true }); } catch {}
+};
+
+exports.test_manageMemory_add_global_writes_to_home_scope = () => {
+  manageMemory(dir, {
+    action: 'add',
+    type: 'assumption',
+    message: 'Prefer concise answers across AI tools',
+    scope: 'global',
+  });
+
+  assert.ok(fs.existsSync(globalMemoryPath));
+  const memory = readMemory(os.homedir());
+  assert.ok(memory.items.some(item => item.message.includes('Prefer concise answers')));
+};
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node test/run.js memory-global`
+Expected: FAIL because `scope` is ignored and memory is not written to the global path
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implementation requirements:
+
+```js
+// In src/mcp-server.js, route list/get/add/update/resolve/archive/delete
+// through a resolved scope root before calling memory helpers.
+
+// In bin/mindswap.js add:
+// .option('--global', 'Use global personal memory scope')
+// .option('--scope <scope>', 'Memory scope: repo, global, all')
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node test/run.js memory-global`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp-server.js bin/mindswap.js test/memory-global.test.js
+git commit -m "feat: add global-scoped memory crud"
+```
+
+### Task 3: Add scoped ask/global recall
+
+**Files:**
+- Modify: `src/ask.js`
+- Modify: `src/mcp-server.js`
+- Modify: `bin/mindswap.js`
+- Test: `test/ask-global.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createTempProject, cleanup } = require('./helpers');
+const { appendMemoryItem } = require('../src/memory');
+const { searchContext } = require('../src/mcp-server');
+
+let dir;
+
+exports.beforeEach = () => {
+  dir = createTempProject('ask-global-test');
+  try { fs.rmSync(path.join(os.homedir(), '.mindswap'), { recursive: true, force: true }); } catch {}
+  appendMemoryItem(os.homedir(), {
+    type: 'assumption',
+    message: 'Prefer direct explanations across tools',
+    tag: 'style',
+  });
+};
+
+exports.afterEach = () => {
+  cleanup(dir);
+  try { fs.rmSync(path.join(os.homedir(), '.mindswap'), { recursive: true, force: true }); } catch {}
+};
+
+exports.test_searchContext_scope_all_includes_global_memory = () => {
+  const result = searchContext(dir, 'direct explanations', 'all', null, { scope: 'all' });
+  const text = result.content[0].text;
+  assert.ok(text.includes('global:assumption'));
+};
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node test/run.js ask-global`
+Expected: FAIL because search only reads repo-scoped context
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implementation requirements:
+
+```js
+// Extend searchContext(projectRoot, query, type, snapshot = null, opts = {})
+// so it can merge global memory items when opts.scope is "global" or "all".
+// Prefix result types with "global:" for global memory lines.
+
+// Extend ask() and CLI options to pass scope through:
+// --global => scope global
+// --scope all => merged recall
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node test/run.js ask-global`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ask.js src/mcp-server.js bin/mindswap.js test/ask-global.test.js
+git commit -m "feat: add scoped global recall for ask and search"
+```
+
+### Task 4: Verify and document shipped behavior
+
+**Files:**
+- Modify: `README.md`
+- Test: `test/mcp-server.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// Add a test that scoped search preserves repo-first relevance
+// when both repo and global memory are present.
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node test/run.js mcp-server`
+Expected: FAIL because mixed-scope ranking is not yet asserted
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implementation requirements:
+
+```md
+## Global personal memory
+
+- `npx mindswap memory add --global --type assumption "..."`
+- `npx mindswap ask --global "..."`
+- `npx mindswap ask --scope all "..."`
+```
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md test/mcp-server.test.js
+git commit -m "docs: explain global personal memory scope"
+```

--- a/docs/superpowers/specs/2026-05-01-local-first-memory-design.md
+++ b/docs/superpowers/specs/2026-05-01-local-first-memory-design.md
@@ -1,0 +1,113 @@
+# Local-First Memory Design
+
+## Goal
+
+Refocus MindSwap around its primary job: carrying context between AI tools using local memory, not hosted infrastructure.
+
+## Product Boundary
+
+MindSwap is a local-first AI memory layer with two scopes:
+
+- global personal memory under `~/.mindswap/`
+- repo memory under `<repo>/.mindswap/`
+
+The global scope stores user-level continuity such as preferences and reusable learnings. The repo scope stores project-specific context such as tasks, blockers, decisions, and generated handoff state.
+
+## Why This Shape
+
+The current codebase is already strong at repo continuity:
+
+- generated context files
+- repo state and task tracking
+- memory CRUD
+- MCP context/search/prompts
+- doctor and resume flows
+
+What it lacks is a first-class memory layer that persists across repos and tools for the same person. Adding a global scope extends the current strengths without forcing a rewrite into a cloud product.
+
+## Storage Design
+
+Human-readable files remain important:
+
+- users can inspect them
+- users can back them up easily
+- repo data stays git-friendly
+
+Design rules:
+
+- repo-generated context stays repo-scoped
+- personal memory is not blindly injected into every repo handoff
+- search and MCP can read both scopes and rank them together
+- commands that mutate memory must know which scope they are writing to
+
+## First Implementation Slice
+
+The first shipped slice should avoid rewriting the entire architecture.
+
+Ship:
+
+- global memory store under `~/.mindswap/memory.json`
+- CLI flags to target `global`, `repo`, or `all`
+- scoped `log`
+- scoped `memory` CRUD
+- scoped `ask`
+- helper functions that resolve the correct memory root
+
+Do not ship in this slice:
+
+- full global state/checkpoint lifecycle
+- global handoff generation
+- SQLite index
+- migrations of all repo commands to dual-scope behavior
+
+## Command Behavior
+
+### `log`
+
+- default behavior inside repos stays repo-scoped
+- `--global` writes to global memory
+
+### `memory`
+
+- supports repo scope by default inside repos
+- supports `--global`
+- supports `--scope repo|global|all`
+- `all` is valid for reads, not writes
+
+### `ask`
+
+- inside repos, default stays repo-focused
+- `--global` searches global memory only
+- `--scope all` searches global memory and repo memory together
+
+## Search Rules
+
+When searching both scopes:
+
+- repo task/blocker/decision context should still outrank unrelated personal memory
+- global preferences and reusable learnings should appear when they are semantically relevant
+- output should surface the scope of each result
+
+## Testing Strategy
+
+Use TDD.
+
+Add tests for:
+
+- global memory file path resolution
+- logging global memory outside repos
+- listing global memory
+- asking global memory
+- combined search result scope labels
+
+## Risks
+
+- leaking personal memory into repo-specific workflows too aggressively
+- making write commands ambiguous when outside repos
+- overloading the current `searchContext` path with too much new scope logic at once
+
+## Initial Mitigation
+
+- keep writes explicit with `--global` or `--scope`
+- keep repo defaults unchanged where possible
+- add shared helper functions rather than spreading scope branching across every command

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mindswap",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mindswap",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindswap",
-  "version": "3.2.2",
-  "mcpName": "io.github.shiporbleed/mindswap",
+  "version": "3.2.3",
+  "mcpName": "io.github.ShipOrBleed/mindswap",
   "description": "Your AI's black box recorder. Auto-track project state so any AI tool picks up where the last one stopped.",
   "main": "src/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,21 +1,27 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.shiporbleed/mindswap",
-  "title": "mindswap",
-  "description": "Your AI's black box recorder. Auto-track project state so any AI tool picks up where the last one stopped.",
+  "name": "io.github.ShipOrBleed/mindswap",
+  "title": "Mindswap",
+  "description": "Local-first AI context and memory server for cross-tool coding continuity.",
   "repository": {
     "url": "https://github.com/ShipOrBleed/mindswap.git",
     "source": "github"
   },
-  "version": "3.2.1",
+  "version": "3.2.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "mindswap",
-      "version": "3.2.1",
+      "version": "3.2.3",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ]
     }
   ]
 }

--- a/src/ask.js
+++ b/src/ask.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const chalk = require('chalk');
 const { getDataDir, readState } = require('./state');
 const { searchContext } = require('./mcp-server');
+const { createProjectSnapshot } = require('./project-snapshot');
 
 async function ask(projectRoot, question, opts = {}) {
   const dataDir = getDataDir(projectRoot);
@@ -16,8 +17,9 @@ async function ask(projectRoot, question, opts = {}) {
     return;
   }
 
-  const state = readState(projectRoot);
-  const search = searchContext(projectRoot, query, 'all');
+  const snapshot = createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
+  const state = snapshot.state || readState(projectRoot);
+  const search = searchContext(projectRoot, query, 'all', snapshot);
   const results = parseSearchResults(search?.content?.[0]?.text || '');
   const payload = buildAnswerPayload(query, results, state);
 

--- a/src/ask.js
+++ b/src/ask.js
@@ -19,7 +19,7 @@ async function ask(projectRoot, question, opts = {}) {
 
   const snapshot = createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
   const state = snapshot.state || readState(projectRoot);
-  const search = searchContext(projectRoot, query, 'all', snapshot);
+  const search = searchContext(projectRoot, query, 'all', snapshot, opts);
   const results = parseSearchResults(search?.content?.[0]?.text || '');
   const payload = buildAnswerPayload(query, results, state);
 

--- a/src/decisions.js
+++ b/src/decisions.js
@@ -4,16 +4,19 @@ const chalk = require('chalk');
 const { getDataDir } = require('./state');
 const { checkConflicts } = require('./conflicts');
 const { appendMemoryItem, normalizeType } = require('./memory');
+const { normalizeScope, getGlobalProjectRoot } = require('./scope');
 
 async function log(projectRoot, message, opts = {}) {
-  const dataDir = getDataDir(projectRoot);
-  if (!fs.existsSync(dataDir)) {
+  const scope = normalizeScope(opts);
+  const targetRoot = scope === 'global' ? getGlobalProjectRoot() : projectRoot;
+  const dataDir = getDataDir(targetRoot);
+  if (!fs.existsSync(dataDir) && scope !== 'global') {
     console.log(chalk.yellow('\nmindswap not initialized. Run: npx mindswap init\n'));
     return;
   }
 
   // Check for conflicts with existing decisions
-  const conflicts = checkConflicts(projectRoot, message);
+  const conflicts = scope === 'global' ? [] : checkConflicts(projectRoot, message);
 
   const decisionsPath = path.join(dataDir, 'decisions.log');
   const timestamp = new Date().toISOString();
@@ -22,10 +25,14 @@ async function log(projectRoot, message, opts = {}) {
 
   if (type === 'decision') {
     const entry = `[${timestamp}] [${tag}] ${message}`;
+    fs.mkdirSync(path.dirname(decisionsPath), { recursive: true });
+    if (!fs.existsSync(decisionsPath)) {
+      fs.writeFileSync(decisionsPath, '', 'utf-8');
+    }
     fs.appendFileSync(decisionsPath, entry + '\n', 'utf-8');
   }
 
-  const memoryItem = appendMemoryItem(projectRoot, {
+  const memoryItem = appendMemoryItem(targetRoot, {
     type,
     tag,
     message,
@@ -36,14 +43,17 @@ async function log(projectRoot, message, opts = {}) {
   // Auto-regenerate HANDOFF.md
   try {
     const { generate } = require('./generate');
-    await generate(projectRoot, { handoff: true, quiet: true });
+    if (scope !== 'global') {
+      await generate(projectRoot, { handoff: true, quiet: true });
+    }
   } catch {}
 
   console.log(chalk.bold('\n⚡ Decision logged\n'));
   console.log(chalk.dim('  Type:    ') + chalk.white(type));
   console.log(chalk.dim('  Tag:     ') + chalk.white(tag));
+  console.log(chalk.dim('  Scope:   ') + chalk.white(scope));
   console.log(chalk.dim('  Message: ') + chalk.white(message));
-  console.log(chalk.dim('  Memory:  ') + chalk.green('.mindswap/memory.json'));
+  console.log(chalk.dim('  Memory:  ') + chalk.green(scope === 'global' ? '~/.mindswap/memory.json' : '.mindswap/memory.json'));
   if (type === 'decision') {
     console.log(chalk.dim('  File:    ') + chalk.green('.mindswap/decisions.log'));
   } else {

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -10,6 +10,7 @@ const { findAllConflicts, checkDepsVsDecisions } = require('./conflicts');
 const { calculateQualityScore } = require('./narrative');
 const { analyzeGuardrails } = require('./guardrails');
 const { getSyncHubPath, readHubSnapshot, buildSyncReport, buildLocalSnapshot } = require('./sync');
+const { createProjectSnapshot } = require('./project-snapshot');
 
 async function doctor(projectRoot, opts = {}) {
   const report = analyzeProjectHealth(projectRoot);
@@ -30,13 +31,6 @@ async function doctor(projectRoot, opts = {}) {
 function analyzeProjectHealth(projectRoot) {
   const dataDir = getDataDir(projectRoot);
   const checks = [];
-  const live = {
-    branch: null,
-    changedFiles: [],
-    recentCommits: [],
-    decisions: [],
-    history: [],
-  };
 
   if (!fs.existsSync(dataDir)) {
     addCheck(checks, 'issue', 'mindswap is not initialized', 'Run `npx mindswap init` in this project.');
@@ -44,6 +38,14 @@ function analyzeProjectHealth(projectRoot) {
   }
 
   addCheck(checks, 'ok', 'mindswap data directory exists');
+  const snapshot = createProjectSnapshot(projectRoot, { historyLimit: 10, recentCommitLimit: 5 });
+  const live = {
+    branch: snapshot.branch,
+    changedFiles: snapshot.changedFiles,
+    recentCommits: snapshot.recentCommits,
+    decisions: snapshot.decisions,
+    history: snapshot.history,
+  };
 
   const statePath = path.join(dataDir, 'state.json');
   const configPath = path.join(dataDir, 'config.json');
@@ -86,7 +88,7 @@ function analyzeProjectHealth(projectRoot) {
 
   let state = null;
   try {
-    state = readState(projectRoot);
+    state = snapshot.state || readState(projectRoot);
   } catch (err) {
     addCheck(checks, 'issue', 'state.json could not be read', err.message);
   }

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,15 +1,15 @@
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
-const { readState, getDataDir, getHistory } = require('./state');
-const { isGitRepo, getCurrentBranch, getAllChangedFiles, getDiffSummary, getDiffContent, getRecentCommits } = require('./git');
+const { readState, getDataDir } = require('./state');
+const { isGitRepo, getDiffSummary, getDiffContent } = require('./git');
 const { buildNarrative, buildCompactNarrative, summarizeFiles } = require('./narrative');
 const { scanAndRedact, printSecretWarnings } = require('./secrets');
 const { detectMonorepo, getMonorepoSection, detectChangedPackages } = require('./monorepo');
 const { teamSection } = require('./team');
-const { getOpenMemoryItems, getMemoryItems } = require('./memory');
-const { parseNativeSessions, getSessionSummary } = require('./session-parser');
-const { analyzeGuardrails, buildGuardrailSection } = require('./guardrails');
+const { getSessionSummary } = require('./session-parser');
+const { buildGuardrailSection } = require('./guardrails');
+const { createProjectSnapshot } = require('./project-snapshot');
 
 const SECTION_START = '<!-- mindswap:start -->';
 const SECTION_END = '<!-- mindswap:end -->';
@@ -163,29 +163,41 @@ function safeWriteContextFile(filePath, content) {
 }
 
 function gatherLiveData(projectRoot) {
-  const data = { branch: null, changedFiles: [], diffSummary: '', recentCommits: [], diff: '' };
+  const snapshot = createProjectSnapshot(projectRoot, {
+    historyLimit: 5,
+    recentCommitLimit: 5,
+  });
+
+  const data = {
+    branch: snapshot.branch,
+    changedFiles: snapshot.changedFiles,
+    diffSummary: '',
+    recentCommits: snapshot.recentCommits,
+    diff: '',
+    decisions: snapshot.decisions.slice(-10),
+    structuredMemory: getStructuredMemory(snapshot),
+    history: snapshot.history.slice(-5),
+  };
+
   if (isGitRepo(projectRoot)) {
-    data.branch = getCurrentBranch(projectRoot);
-    data.changedFiles = getAllChangedFiles(projectRoot);
     data.diffSummary = getDiffSummary(projectRoot);
-    data.recentCommits = getRecentCommits(projectRoot, 5);
     data.diff = getDiffContent(projectRoot, 150);
   }
-  const decisionsPath = path.join(projectRoot, '.mindswap', 'decisions.log');
-  data.decisions = [];
-  if (fs.existsSync(decisionsPath)) {
-    data.decisions = fs.readFileSync(decisionsPath, 'utf-8')
-      .split('\n')
-      .filter(l => l.startsWith('['))
-      .slice(-10);
-  }
-  data.structuredMemory = getStructuredMemory(projectRoot);
-  data.history = getHistory(projectRoot, 5);
-  data.nativeSessions = parseNativeSessions(projectRoot);
-  data.guardrails = analyzeGuardrails(projectRoot, {
-    changedFiles: data.changedFiles,
-    diffContent: data.diff,
+
+  Object.defineProperty(data, 'nativeSessions', {
+    enumerable: true,
+    get() {
+      return snapshot.nativeSessions;
+    },
   });
+
+  Object.defineProperty(data, 'guardrails', {
+    enumerable: true,
+    get() {
+      return snapshot.guardrails;
+    },
+  });
+
   return data;
 }
 
@@ -464,12 +476,13 @@ ${live.changedFiles.slice(0, 15).map(f => `${f.status}: ${f.file}`).join('\n') |
 `;
 }
 
-function getStructuredMemory(projectRoot) {
+function getStructuredMemory(snapshot) {
+  const items = Array.isArray(snapshot?.memory?.items) ? snapshot.memory.items : [];
   return {
-    blockers: getOpenMemoryItems(projectRoot, 'blocker', 5),
-    assumptions: getOpenMemoryItems(projectRoot, 'assumption', 5),
-    questions: getOpenMemoryItems(projectRoot, 'question', 5),
-    resolutions: getMemoryItems(projectRoot, { type: 'resolution', limit: 5 }),
+    blockers: items.filter(item => item.type === 'blocker' && item.status === 'open').slice(-5),
+    assumptions: items.filter(item => item.type === 'assumption' && item.status === 'open').slice(-5),
+    questions: items.filter(item => item.type === 'question' && item.status === 'open').slice(-5),
+    resolutions: items.filter(item => item.type === 'resolution').slice(-5),
   };
 }
 

--- a/src/index-store.js
+++ b/src/index-store.js
@@ -6,12 +6,34 @@ const { createProjectSnapshot } = require('./project-snapshot');
 const { getGlobalProjectRoot, normalizeScope } = require('./scope');
 
 let sqlite = null;
-try {
-  sqlite = require('node:sqlite');
-} catch {}
+let sqliteLoaded = false;
+
+function getSqlite() {
+  if (sqliteLoaded) return sqlite;
+  sqliteLoaded = true;
+
+  const originalEmitWarning = process.emitWarning;
+  process.emitWarning = function emitWarningWithoutSqliteNoise(warning, ...args) {
+    const message = typeof warning === 'string' ? warning : warning?.message || '';
+    const type = typeof args[0] === 'string' ? args[0] : args[0]?.type;
+    if (type === 'ExperimentalWarning' && /SQLite/i.test(message)) return;
+    return originalEmitWarning.call(process, warning, ...args);
+  };
+
+  try {
+    sqlite = require('node:sqlite');
+  } catch {
+    sqlite = null;
+  } finally {
+    process.emitWarning = originalEmitWarning;
+  }
+
+  return sqlite;
+}
 
 function isSqliteAvailable() {
-  return Boolean(sqlite && sqlite.DatabaseSync);
+  const runtime = getSqlite();
+  return Boolean(runtime && runtime.DatabaseSync);
 }
 
 function getIndexDbPath(projectRoot) {
@@ -79,7 +101,7 @@ function searchIndexedEntries(projectRoot, query, opts = {}) {
 }
 
 function openIndexDb(dbPath) {
-  const { DatabaseSync } = sqlite;
+  const { DatabaseSync } = getSqlite();
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   const db = new DatabaseSync(dbPath);
   db.exec(`

--- a/src/index-store.js
+++ b/src/index-store.js
@@ -1,0 +1,204 @@
+const fs = require('fs');
+const path = require('path');
+const { getDataDir } = require('./state');
+const { readMemory } = require('./memory');
+const { createProjectSnapshot } = require('./project-snapshot');
+const { getGlobalProjectRoot, normalizeScope } = require('./scope');
+
+let sqlite = null;
+try {
+  sqlite = require('node:sqlite');
+} catch {}
+
+function isSqliteAvailable() {
+  return Boolean(sqlite && sqlite.DatabaseSync);
+}
+
+function getIndexDbPath(projectRoot) {
+  return path.join(getDataDir(projectRoot), 'mindswap.db');
+}
+
+function rebuildSearchIndex(projectRoot, opts = {}) {
+  if (!isSqliteAvailable()) {
+    return {
+      ok: false,
+      indexed: 0,
+      scope: normalizeScope(opts),
+      db_path: null,
+      reason: 'SQLite runtime is not available in this Node.js environment.',
+    };
+  }
+
+  const scope = normalizeScope(opts);
+  const dbPath = getIndexDbPath(projectRoot);
+  const db = openIndexDb(dbPath);
+  try {
+    db.exec('DELETE FROM documents;');
+    let indexed = 0;
+
+    if (scope === 'repo' || scope === 'all') {
+      indexed += indexRepoDocuments(db, projectRoot);
+    }
+
+    if (scope === 'global' || scope === 'all') {
+      indexed += indexGlobalDocuments(db);
+    }
+
+    return {
+      ok: true,
+      indexed,
+      scope,
+      db_path: dbPath,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function searchIndexedEntries(projectRoot, query, opts = {}) {
+  if (!isSqliteAvailable()) return [];
+  const dbPath = getIndexDbPath(projectRoot);
+  if (!fs.existsSync(dbPath)) return [];
+
+  const scope = normalizeScope(opts);
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return [];
+
+  const db = openIndexDb(dbPath);
+  try {
+    const rows = db.prepare('SELECT key, scope, type, source, content FROM documents').all();
+    return rows
+      .filter(row => scope === 'all' || row.scope === scope)
+      .map(row => ({ ...row, score: scoreRow(row.content, tokens) }))
+      .filter(row => row.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, Number(opts.limit) || 10);
+  } finally {
+    db.close();
+  }
+}
+
+function openIndexDb(dbPath) {
+  const { DatabaseSync } = sqlite;
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS documents (
+      key TEXT PRIMARY KEY,
+      scope TEXT NOT NULL,
+      type TEXT NOT NULL,
+      source TEXT NOT NULL,
+      content TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+function indexRepoDocuments(db, projectRoot) {
+  const snapshot = createProjectSnapshot(projectRoot, { historyLimit: 50, recentCommitLimit: 5 });
+  let count = 0;
+
+  for (const [index, line] of snapshot.decisions.entries()) {
+    insertDocument(db, {
+      key: `repo:decision:${index}:${line}`,
+      scope: 'repo',
+      type: 'decision',
+      source: 'decisions.log',
+      content: line,
+    });
+    count += 1;
+  }
+
+  for (const [index, entry] of snapshot.history.entries()) {
+    insertDocument(db, {
+      key: `repo:history:${index}:${entry.timestamp || ''}:${entry.message || ''}`,
+      scope: 'repo',
+      type: 'history',
+      source: 'history',
+      content: entry.message || '',
+    });
+    count += 1;
+  }
+
+  for (const item of snapshot.memory?.items || []) {
+    insertDocument(db, {
+      key: `repo:memory:${item.id || `${item.type}:${item.message}`}`,
+      scope: 'repo',
+      type: `memory:${item.type}`,
+      source: 'memory',
+      content: item.message || '',
+    });
+    count += 1;
+  }
+
+  if (snapshot.state?.current_task?.description) {
+    insertDocument(db, {
+      key: `repo:task:${snapshot.state.current_task.description}`,
+      scope: 'repo',
+      type: 'task',
+      source: 'state.current_task',
+      content: snapshot.state.current_task.description,
+    });
+    count += 1;
+  }
+
+  if (snapshot.state?.current_task?.blocker) {
+    insertDocument(db, {
+      key: `repo:blocker:${snapshot.state.current_task.blocker}`,
+      scope: 'repo',
+      type: 'blocker',
+      source: 'state.current_task',
+      content: snapshot.state.current_task.blocker,
+    });
+    count += 1;
+  }
+
+  return count;
+}
+
+function indexGlobalDocuments(db) {
+  const memory = readMemory(getGlobalProjectRoot());
+  let count = 0;
+  for (const item of memory.items || []) {
+    insertDocument(db, {
+      key: `global:memory:${item.id || `${item.type}:${item.message}`}`,
+      scope: 'global',
+      type: `memory:${item.type}`,
+      source: 'global-memory',
+      content: item.message || '',
+    });
+    count += 1;
+  }
+  return count;
+}
+
+function insertDocument(db, doc) {
+  db.prepare(`
+    INSERT OR REPLACE INTO documents (key, scope, type, source, content)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(doc.key, doc.scope, doc.type, doc.source, doc.content);
+}
+
+function tokenize(query) {
+  return String(query || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/i)
+    .map(token => token.trim())
+    .filter(Boolean);
+}
+
+function scoreRow(content, tokens) {
+  const haystack = String(content || '').toLowerCase();
+  let score = 0;
+  for (const token of tokens) {
+    if (haystack.includes(token)) score += 1;
+  }
+  return score;
+}
+
+module.exports = {
+  isSqliteAvailable,
+  getIndexDbPath,
+  rebuildSearchIndex,
+  searchIndexedEntries,
+};

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -107,10 +107,14 @@ function createMCPServer(projectRoot) {
       query: z.string().describe('What to search for (e.g., "auth", "database choice", "why Redis")'),
       type: z.enum(['all', 'decisions', 'history']).default('all')
         .describe('Where to search: "all" searches everything, "decisions" only searches decision log, "history" only searches session history'),
+      global: z.boolean().default(false)
+        .describe('Search global personal memory'),
+      scope: z.enum(['repo', 'global', 'all']).optional()
+        .describe('Search scope: repo, global, or all'),
     },
-    async ({ query, type }) => {
+    async ({ query, type, global, scope }) => {
       const snapshot = createProjectSnapshot(projectRoot, getSnapshotOptionsForSearch(type));
-      return searchContext(projectRoot, query, type, snapshot);
+      return searchContext(projectRoot, query, type, snapshot, { global, scope });
     }
   );
 
@@ -146,6 +150,10 @@ function createMCPServer(projectRoot) {
         .describe('Only include items created before this timestamp'),
       hard: z.boolean().default(false)
         .describe('Hard delete instead of archiving'),
+      global: z.boolean().default(false)
+        .describe('Use global personal memory scope'),
+      scope: z.enum(['repo', 'global', 'all']).optional()
+        .describe('Memory scope: repo, global, or all. Writes require repo or global.'),
       json: z.boolean().default(false)
         .describe('Return JSON instead of formatted text'),
     },

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -8,7 +8,6 @@ const fs = require('fs');
 const path = require('path');
 
 const { readState, getDataDir, getHistory } = require('./state');
-const { isGitRepo, getCurrentBranch, getAllChangedFiles, getRecentCommits } = require('./git');
 const { buildNarrative, buildCompactNarrative, calculateQualityScore } = require('./narrative');
 const { findAllConflicts, checkDepsVsDecisions } = require('./conflicts');
 const { detectAITool } = require('./detect-ai');
@@ -31,6 +30,7 @@ const {
 const { parseNativeSessions, getSessionSummary } = require('./session-parser');
 const { analyzeGuardrails, buildGuardrailSection } = require('./guardrails');
 const { buildResumeBriefing, gatherResumeData } = require('./resume');
+const { createProjectSnapshot, readDecisionLines } = require('./project-snapshot');
 
 /**
  * Start the mindswap MCP server.
@@ -433,7 +433,7 @@ async function startMCPHttpServer(options = {}) {
 // Tool implementations
 // ═══════════════════════════════════════════════════
 
-function getContext(projectRoot, focus, compact) {
+function getContext(projectRoot, focus, compact, snapshot = null) {
   const dataDir = getDataDir(projectRoot);
   if (!fs.existsSync(dataDir)) {
     return {
@@ -444,8 +444,9 @@ function getContext(projectRoot, focus, compact) {
     };
   }
 
-  const state = readState(projectRoot);
-  const liveData = gatherLiveData(projectRoot);
+  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
+  const state = currentSnapshot.state;
+  const liveData = snapshotToLiveData(currentSnapshot);
 
   if (compact) {
     const compactText = buildCompactNarrative(state, liveData);
@@ -483,7 +484,7 @@ function getContext(projectRoot, focus, compact) {
       sections.push(`## Decisions\n${stripped.map(d => `- ${d}`).join('\n')}`);
     }
 
-    const memoryLines = formatMemorySection(projectRoot);
+    const memoryLines = formatMemorySection(currentSnapshot);
     if (memoryLines.length > 0) {
       sections.push(`## Structured Memory\n${memoryLines.join('\n')}`);
     }
@@ -665,7 +666,7 @@ function saveContext(projectRoot, { summary, decisions, assumptions, questions, 
   };
 }
 
-function searchContext(projectRoot, query, type) {
+function searchContext(projectRoot, query, type, snapshot = null) {
   const dataDir = getDataDir(projectRoot);
   if (!fs.existsSync(dataDir)) {
     return {
@@ -673,32 +674,25 @@ function searchContext(projectRoot, query, type) {
     };
   }
 
+  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, { historyLimit: 50, recentCommitLimit: 5 });
   const queryTokens = tokenize(query);
   const results = [];
   const seen = new Set();
 
   // Search decisions
   if (type === 'all' || type === 'decisions') {
-    const decisionsPath = path.join(dataDir, 'decisions.log');
-    if (fs.existsSync(decisionsPath)) {
-      const lines = fs.readFileSync(decisionsPath, 'utf-8')
-        .split('\n')
-        .filter(l => l.startsWith('['));
-
-      for (const line of lines) {
-        addScoredResult(results, seen, {
-          type: 'decision',
-          content: line,
-          source: 'decisions.log',
-        }, queryTokens, 1.2);
-      }
+    for (const line of currentSnapshot.decisions) {
+      addScoredResult(results, seen, {
+        type: 'decision',
+        content: line,
+        source: 'decisions.log',
+      }, queryTokens, 1.2);
     }
   }
 
   // Search history
   if (type === 'all' || type === 'history') {
-    const history = getHistory(projectRoot, 50);
-    for (const entry of history) {
+    for (const entry of currentSnapshot.history) {
       addScoredResult(results, seen, {
         type: 'history',
         content: `[${entry.timestamp}] ${entry.message}${entry.ai_tool ? ` (${entry.ai_tool})` : ''}`,
@@ -709,8 +703,7 @@ function searchContext(projectRoot, query, type) {
 
   // Search current state
   if (type === 'all') {
-    const memoryItems = getRecentMemoryItems(projectRoot, 50);
-    for (const item of memoryItems) {
+    for (const item of listMemoryItemsFromSnapshot(currentSnapshot, { limit: 50 })) {
       addScoredResult(results, seen, {
         type: `memory:${item.type}`,
         content: `${item.type}: ${item.message} [${item.status}]`,
@@ -718,7 +711,7 @@ function searchContext(projectRoot, query, type) {
       }, queryTokens, item.status === 'open' ? 1.15 : 1.0, `${item.type} ${item.tag} ${item.status} ${item.message}`);
     }
 
-    const state = readState(projectRoot);
+    const state = currentSnapshot.state;
     if (state.current_task?.description) {
       addScoredResult(results, seen, {
         type: 'task',
@@ -743,8 +736,7 @@ function searchContext(projectRoot, query, type) {
   }
 
   if (type === 'all') {
-    const nativeSessions = parseNativeSessions(projectRoot) || [];
-    for (const session of nativeSessions) {
+    for (const session of currentSnapshot.nativeSessions) {
       const combined = [
         session.summary || '',
         session.blockers?.join(' '),
@@ -760,8 +752,7 @@ function searchContext(projectRoot, query, type) {
       }, queryTokens, 0.9, combined || session.rawText || session.tool);
     }
 
-    const imported = importSessions(projectRoot) || [];
-    for (const session of imported) {
+    for (const session of currentSnapshot.importedSessions) {
       const sourceLabel = session.tool || 'session';
       const combined = [...(session.decisions || []), ...(session.context || [])].join(' ');
       addScoredResult(results, seen, {
@@ -793,17 +784,18 @@ function searchContext(projectRoot, query, type) {
   };
 }
 
-function renderContextText(projectRoot, focus = 'all', compact = false) {
-  const context = getContext(projectRoot, focus, compact);
+function renderContextText(projectRoot, focus = 'all', compact = false, snapshot = null) {
+  const context = getContext(projectRoot, focus, compact, snapshot);
   return context?.content?.[0]?.text || '';
 }
 
-function readStableResource(projectRoot, kind) {
-  const state = readState(projectRoot);
-  const liveData = gatherLiveData(projectRoot);
-  const memory = readMemory(projectRoot);
+function readStableResource(projectRoot, kind, snapshot = null) {
+  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
+  const state = currentSnapshot.state;
+  const liveData = snapshotToLiveData(currentSnapshot);
+  const memory = currentSnapshot.memory;
   const handoffPath = path.join(projectRoot, 'HANDOFF.md');
-  const handoffText = fs.existsSync(handoffPath) ? fs.readFileSync(handoffPath, 'utf-8') : renderContextText(projectRoot, 'all', false);
+  const handoffText = fs.existsSync(handoffPath) ? fs.readFileSync(handoffPath, 'utf-8') : renderContextText(projectRoot, 'all', false, currentSnapshot);
 
   switch (kind) {
     case 'context':
@@ -883,8 +875,8 @@ function readRequestBody(req) {
   });
 }
 
-function buildStartWorkPrompt(projectRoot, { goal, tool, compact } = {}) {
-  const contextText = renderContextText(projectRoot, compact ? 'task' : 'all', Boolean(compact));
+function buildStartWorkPrompt(projectRoot, { goal, tool, compact } = {}, snapshot = null) {
+  const contextText = renderContextText(projectRoot, compact ? 'task' : 'all', Boolean(compact), snapshot);
   const lines = ['You are starting work in this repository.'];
   if (tool) lines.push(`Target tool: ${tool}.`);
   if (goal) lines.push(`Goal: ${goal}.`);
@@ -897,8 +889,9 @@ function buildStartWorkPrompt(projectRoot, { goal, tool, compact } = {}) {
   return lines.join('\n');
 }
 
-function buildResumeWorkPrompt(projectRoot, { compact } = {}) {
-  const briefing = buildResumeBriefing(readState(projectRoot), gatherResumeData(projectRoot), { compact });
+function buildResumeWorkPrompt(projectRoot, { compact } = {}, snapshot = null) {
+  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
+  const briefing = buildResumeBriefing(currentSnapshot.state, gatherResumeData(projectRoot, currentSnapshot), { compact });
   const lines = [
     'Resume this workstream from the current repo state.',
     '',
@@ -919,8 +912,8 @@ function buildResumeWorkPrompt(projectRoot, { compact } = {}) {
   return lines.join('\n');
 }
 
-function buildHandoffPrompt(projectRoot, { audience } = {}) {
-  const contextText = renderContextText(projectRoot, 'all', false);
+function buildHandoffPrompt(projectRoot, { audience } = {}, snapshot = null) {
+  const contextText = renderContextText(projectRoot, 'all', false, snapshot);
   const lines = [
     audience ? `Prepare a handoff for ${audience}.` : 'Prepare a handoff for the next agent.',
     'Summarize what changed, what is still open, and what should happen next.',
@@ -933,8 +926,8 @@ function buildHandoffPrompt(projectRoot, { audience } = {}) {
   return lines.join('\n');
 }
 
-function buildConflictReviewPrompt(projectRoot, { focus } = {}) {
-  const contextText = renderContextText(projectRoot, 'decisions', false);
+function buildConflictReviewPrompt(projectRoot, { focus } = {}, snapshot = null) {
+  const contextText = renderContextText(projectRoot, 'decisions', false, snapshot);
   const lines = [
     focus ? `Review conflicts with a focus on ${focus}.` : 'Review the current decision and dependency conflicts.',
     'Identify contradictions, explain the impact, and propose the smallest safe resolution.',
@@ -1059,36 +1052,20 @@ function manageMemory(projectRoot, opts = {}) {
 // ═══════════════════════════════════════════════════
 
 function gatherLiveData(projectRoot) {
-  const data = {
-    branch: null,
-    changedFiles: [],
-    recentCommits: [],
-    decisions: [],
-    history: [],
-    nativeSessions: [],
+  return snapshotToLiveData(createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 }));
+}
+
+function snapshotToLiveData(snapshot) {
+  return {
+    branch: snapshot.branch,
+    changedFiles: snapshot.changedFiles,
+    recentCommits: snapshot.recentCommits,
+    decisions: snapshot.decisions,
+    history: snapshot.history,
+    nativeSessions: snapshot.nativeSessions,
+    structuredMemory: snapshot.memory?.items || [],
+    guardrails: snapshot.guardrails,
   };
-
-  if (isGitRepo(projectRoot)) {
-    data.branch = getCurrentBranch(projectRoot);
-    data.changedFiles = getAllChangedFiles(projectRoot);
-    data.recentCommits = getRecentCommits(projectRoot, 5);
-  }
-
-  const decisionsPath = path.join(projectRoot, '.mindswap', 'decisions.log');
-  if (fs.existsSync(decisionsPath)) {
-    data.decisions = fs.readFileSync(decisionsPath, 'utf-8')
-      .split('\n')
-      .filter(l => l.startsWith('['));
-  }
-
-  data.structuredMemory = getRecentMemoryItems(projectRoot, 20);
-  data.history = getHistory(projectRoot, 5);
-  data.nativeSessions = parseNativeSessions(projectRoot);
-  data.guardrails = analyzeGuardrails(projectRoot, {
-    changedFiles: data.changedFiles,
-    diffContent: '',
-  });
-  return data;
 }
 
 function tokenize(query) {
@@ -1164,15 +1141,49 @@ const QUERY_ALIASES = {
   ui: ['frontend', 'component', 'page', 'view'],
 };
 
-function formatMemorySection(projectRoot) {
+function formatMemorySection(snapshot) {
   const lines = [];
-  for (const item of getOpenMemoryItems(projectRoot, 'blocker', 5)) lines.push(`- BLOCKER: ${item.message}`);
-  for (const item of getOpenMemoryItems(projectRoot, 'question', 5)) lines.push(`- QUESTION: ${item.message}`);
-  for (const item of getOpenMemoryItems(projectRoot, 'assumption', 5)) lines.push(`- ASSUMPTION: ${item.message}`);
-  for (const item of getRecentMemoryItems(projectRoot, 10).filter(item => item.type === 'resolution').slice(-5)) {
+  for (const item of getSnapshotMemoryItems(snapshot, { type: 'blocker', status: 'open', limit: 5 })) lines.push(`- BLOCKER: ${item.message}`);
+  for (const item of getSnapshotMemoryItems(snapshot, { type: 'question', status: 'open', limit: 5 })) lines.push(`- QUESTION: ${item.message}`);
+  for (const item of getSnapshotMemoryItems(snapshot, { type: 'assumption', status: 'open', limit: 5 })) lines.push(`- ASSUMPTION: ${item.message}`);
+  for (const item of getSnapshotMemoryItems(snapshot, { type: 'resolution', limit: 10 }).slice(-5)) {
     lines.push(`- RESOLUTION: ${item.message}`);
   }
   return lines;
+}
+
+function getSnapshotMemoryItems(snapshot, opts = {}) {
+  const items = Array.isArray(snapshot.memory?.items) ? snapshot.memory.items.slice() : [];
+  let filtered = items;
+  if (opts.type) {
+    const types = Array.isArray(opts.type) ? opts.type : [opts.type];
+    filtered = filtered.filter(item => types.includes(item.type));
+  }
+  if (opts.status) {
+    filtered = filtered.filter(item => item.status === opts.status);
+  }
+  if (opts.source) {
+    const sources = Array.isArray(opts.source) ? opts.source : [opts.source];
+    filtered = filtered.filter(item => sources.includes(item.source));
+  }
+  if (opts.author) {
+    const authors = Array.isArray(opts.author) ? opts.author : [opts.author];
+    filtered = filtered.filter(item => authors.includes(item.author));
+  }
+  if (opts.limit) {
+    const limit = Number(opts.limit);
+    if (Number.isFinite(limit) && limit > 0) {
+      filtered = filtered.slice(-limit);
+    }
+  }
+  return filtered;
+}
+
+function listMemoryItemsFromSnapshot(snapshot, opts = {}) {
+  return getSnapshotMemoryItems(snapshot, {
+    ...opts,
+    includeArchived: opts.includeArchived || opts.status === 'archived',
+  });
 }
 
 function formatMemoryResult(result) {

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -31,6 +31,8 @@ const { parseNativeSessions, getSessionSummary } = require('./session-parser');
 const { analyzeGuardrails, buildGuardrailSection } = require('./guardrails');
 const { buildResumeBriefing, gatherResumeData } = require('./resume');
 const { createProjectSnapshot, readDecisionLines } = require('./project-snapshot');
+const { normalizeScope, resolveMemoryRoots, getGlobalProjectRoot, canUseRepoScope } = require('./scope');
+const { isSqliteAvailable, getIndexDbPath, searchIndexedEntries } = require('./index-store');
 
 /**
  * Start the mindswap MCP server.
@@ -680,21 +682,48 @@ function saveContext(projectRoot, { summary, decisions, assumptions, questions, 
   };
 }
 
-function searchContext(projectRoot, query, type, snapshot = null) {
+function searchContext(projectRoot, query, type, snapshot = null, opts = {}) {
   const dataDir = getDataDir(projectRoot);
-  if (!fs.existsSync(dataDir)) {
+  const scope = normalizeScope(opts);
+  if (!fs.existsSync(dataDir) && scope === 'repo') {
     return {
       content: [{ type: 'text', text: 'mindswap not initialized. Run `npx mindswap init` first.' }],
     };
   }
 
-  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, { historyLimit: 50, recentCommitLimit: 5 });
+  const preferIndex = opts.index !== false && type === 'all' && isSqliteAvailable();
+  if (preferIndex) {
+    const indexPath = getIndexDbPath(projectRoot);
+    if (fs.existsSync(indexPath)) {
+      const hits = searchIndexedEntries(projectRoot, query, { scope, limit: 15 });
+      if (hits.length > 0) {
+        const formatted = hits
+          .map(hit => {
+            const label = formatIndexHitType(hit);
+            const score = Math.max(1, Number(hit.score) || 1);
+            return `[${label}] (${score}) ${hit.content}`;
+          })
+          .join('\n');
+
+        return {
+          content: [{
+            type: 'text',
+            text: `Found ${hits.length} indexed result(s) for "${query}":\n\n${formatted}`,
+          }],
+        };
+      }
+    }
+  }
+
+  const currentSnapshot = fs.existsSync(dataDir)
+    ? (snapshot || createProjectSnapshot(projectRoot, { historyLimit: 50, recentCommitLimit: 5 }))
+    : null;
   const queryTokens = tokenize(query);
   const results = [];
   const seen = new Set();
 
   // Search decisions
-  if (type === 'all' || type === 'decisions') {
+  if (currentSnapshot && (type === 'all' || type === 'decisions')) {
     for (const line of currentSnapshot.decisions) {
       addScoredResult(results, seen, {
         type: 'decision',
@@ -706,7 +735,7 @@ function searchContext(projectRoot, query, type, snapshot = null) {
   }
 
   // Search history
-  if (type === 'all' || type === 'history') {
+  if (currentSnapshot && (type === 'all' || type === 'history')) {
     for (const entry of currentSnapshot.history) {
       addScoredResult(results, seen, {
         type: 'history',
@@ -718,7 +747,7 @@ function searchContext(projectRoot, query, type, snapshot = null) {
   }
 
   // Search current state
-  if (type === 'all') {
+  if (currentSnapshot && type === 'all') {
     for (const item of listMemoryItemsFromSnapshot(currentSnapshot, { limit: 50 })) {
       addScoredResult(results, seen, {
         type: `memory:${item.type}`,
@@ -755,7 +784,7 @@ function searchContext(projectRoot, query, type, snapshot = null) {
     }
   }
 
-  if (type === 'all') {
+  if (currentSnapshot && type === 'all') {
     for (const session of currentSnapshot.nativeSessions) {
       const combined = [
         session.summary || '',
@@ -785,6 +814,17 @@ function searchContext(projectRoot, query, type, snapshot = null) {
     }
   }
 
+  if (type === 'all' && (scope === 'global' || scope === 'all')) {
+    for (const item of listMemoryItems(getGlobalProjectRoot(), { limit: 50 })) {
+      addScoredResult(results, seen, {
+        type: `global:${item.type}`,
+        content: createSearchSnippet(`${item.type}: ${item.message}`, queryTokens),
+        source: 'global-memory',
+        key: `global:${item.id || `${item.type}:${item.tag}:${item.message}`}`,
+      }, queryTokens, item.status === 'open' ? 1.15 : 0.9, `${item.type} ${item.tag} ${item.status} ${item.message}`, item.status === 'open' ? 2 : 1);
+    }
+  }
+
   if (results.length === 0) {
     return {
       content: [{
@@ -804,6 +844,18 @@ function searchContext(projectRoot, query, type, snapshot = null) {
       text: `Found ${results.length} result(s) for "${query}":\n\n${formatted}`,
     }],
   };
+}
+
+function formatIndexHitType(hit) {
+  const scope = hit.scope === 'global' ? 'global' : 'repo';
+  const raw = String(hit.type || '').trim();
+  if (!raw) return scope;
+  if (scope === 'global') {
+    // Match existing global labels: global:<memory-type>
+    if (raw.startsWith('memory:')) return `global:${raw.slice('memory:'.length)}`;
+    return `global:${raw}`;
+  }
+  return raw;
 }
 
 function renderContextText(projectRoot, focus = 'all', compact = false, snapshot = null) {
@@ -962,8 +1014,13 @@ function buildConflictReviewPrompt(projectRoot, { focus } = {}, snapshot = null)
 }
 
 function manageMemory(projectRoot, opts = {}) {
-  const dataDir = getDataDir(projectRoot);
-  if (!fs.existsSync(dataDir)) {
+  const scope = normalizeScope(opts);
+  if (scope === 'all' && !['list', 'get'].includes(String(opts.action || '').toLowerCase())) {
+    throw new Error('memory writes require repo or global scope');
+  }
+
+  const repoReady = canUseRepoScope(projectRoot);
+  if (!repoReady && scope === 'repo') {
     return {
       content: [{ type: 'text', text: 'mindswap not initialized. Run `npx mindswap init` first.' }],
     };
@@ -971,11 +1028,16 @@ function manageMemory(projectRoot, opts = {}) {
 
   const action = String(opts.action || '').toLowerCase();
   const now = new Date().toISOString();
+  const roots = resolveMemoryRoots(projectRoot, opts).filter(root => {
+    if (root === projectRoot) return repoReady;
+    return true;
+  });
+  const primaryRoot = roots[0];
 
   let result = null;
   switch (action) {
     case 'list': {
-      const items = listMemoryItems(projectRoot, {
+      const items = roots.flatMap(root => listMemoryItems(root, {
         type: opts.type,
         status: opts.status,
         author: opts.author,
@@ -984,19 +1046,24 @@ function manageMemory(projectRoot, opts = {}) {
         created_before: opts.before,
         includeArchived: opts.status === 'archived' || opts.hard === true,
         limit: opts.limit || 20,
-      });
+      }).map(item => ({ ...item, scope: root === getGlobalProjectRoot() ? 'global' : 'repo' })));
       result = { action, count: items.length, items };
       break;
     }
     case 'get': {
       if (!opts.id) throw new Error('memory get requires an id');
-      const item = getMemoryItemById(projectRoot, opts.id);
+      const item = roots
+        .map(root => {
+          const found = getMemoryItemById(root, opts.id);
+          return found ? { ...found, scope: root === getGlobalProjectRoot() ? 'global' : 'repo' } : null;
+        })
+        .find(Boolean);
       result = item ? { action, item } : { action, item: null };
       break;
     }
     case 'add': {
       if (!opts.message) throw new Error('memory add requires a message');
-      const item = appendMemoryItem(projectRoot, {
+      const item = appendMemoryItem(primaryRoot, {
         type: opts.type || 'decision',
         tag: opts.tag || 'general',
         message: opts.message,
@@ -1005,12 +1072,13 @@ function manageMemory(projectRoot, opts = {}) {
         source: opts.source || 'cli',
         created_at: now,
       });
-      result = { action, item };
+      result = { action, item: { ...item, scope: primaryRoot === getGlobalProjectRoot() ? 'global' : 'repo' } };
       break;
     }
     case 'update': {
       if (!opts.id) throw new Error('memory update requires an id');
-      const item = updateMemoryItem(projectRoot, opts.id, {
+      const targetRoot = roots.find(root => getMemoryItemById(root, opts.id)) || primaryRoot;
+      const item = updateMemoryItem(targetRoot, opts.id, {
         type: opts.type,
         tag: opts.tag,
         message: opts.message,
@@ -1020,12 +1088,13 @@ function manageMemory(projectRoot, opts = {}) {
         updated_at: now,
       });
       if (!item) throw new Error(`memory item not found: ${opts.id}`);
-      result = { action, item };
+      result = { action, item: { ...item, scope: targetRoot === getGlobalProjectRoot() ? 'global' : 'repo' } };
       break;
     }
     case 'resolve': {
       if (!opts.id) throw new Error('memory resolve requires an id');
-      const item = resolveMemoryItem(projectRoot, opts.id, {
+      const targetRoot = roots.find(root => getMemoryItemById(root, opts.id)) || primaryRoot;
+      const item = resolveMemoryItem(targetRoot, opts.id, {
         message: opts.message,
         tag: opts.tag,
         author: opts.author,
@@ -1033,12 +1102,13 @@ function manageMemory(projectRoot, opts = {}) {
         resolved_at: now,
       });
       if (!item) throw new Error(`memory item not found: ${opts.id}`);
-      result = { action, item };
+      result = { action, item: { ...item, scope: targetRoot === getGlobalProjectRoot() ? 'global' : 'repo' } };
       break;
     }
     case 'archive': {
       if (!opts.id) throw new Error('memory archive requires an id');
-      const item = archiveMemoryItem(projectRoot, opts.id, {
+      const targetRoot = roots.find(root => getMemoryItemById(root, opts.id)) || primaryRoot;
+      const item = archiveMemoryItem(targetRoot, opts.id, {
         message: opts.message,
         tag: opts.tag,
         author: opts.author,
@@ -1046,14 +1116,19 @@ function manageMemory(projectRoot, opts = {}) {
         archived_at: now,
       });
       if (!item) throw new Error(`memory item not found: ${opts.id}`);
-      result = { action, item };
+      result = { action, item: { ...item, scope: targetRoot === getGlobalProjectRoot() ? 'global' : 'repo' } };
       break;
     }
     case 'delete': {
       if (!opts.id) throw new Error('memory delete requires an id');
-      const item = deleteMemoryItem(projectRoot, opts.id, { hard: Boolean(opts.hard), archived_at: now });
+      const targetRoot = roots.find(root => getMemoryItemById(root, opts.id)) || primaryRoot;
+      const item = deleteMemoryItem(targetRoot, opts.id, { hard: Boolean(opts.hard), archived_at: now });
       if (!item) throw new Error(`memory item not found: ${opts.id}`);
-      result = { action, item, deleted: Boolean(opts.hard) };
+      result = {
+        action,
+        item: { ...item, scope: targetRoot === getGlobalProjectRoot() ? 'global' : 'repo' },
+        deleted: Boolean(opts.hard),
+      };
       break;
     }
     default:

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -58,7 +58,8 @@ function createMCPServer(projectRoot) {
         .describe('Return token-optimized compact format (fewer tokens, same info)'),
     },
     async ({ focus, compact }) => {
-      return getContext(projectRoot, focus, compact);
+      const snapshot = createProjectSnapshot(projectRoot, getSnapshotOptionsForContext(focus, compact));
+      return getContext(projectRoot, focus, compact, snapshot);
     }
   );
 
@@ -106,7 +107,8 @@ function createMCPServer(projectRoot) {
         .describe('Where to search: "all" searches everything, "decisions" only searches decision log, "history" only searches session history'),
     },
     async ({ query, type }) => {
-      return searchContext(projectRoot, query, type);
+      const snapshot = createProjectSnapshot(projectRoot, getSnapshotOptionsForSearch(type));
+      return searchContext(projectRoot, query, type, snapshot);
     }
   );
 
@@ -217,15 +219,18 @@ function createMCPServer(projectRoot) {
         compact: z.string().optional().describe('Set to "true" for a shorter prompt body'),
       },
     },
-    async ({ goal, tool, compact }) => ({
-      messages: [{
-        role: 'user',
-        content: {
-          type: 'text',
-          text: buildStartWorkPrompt(projectRoot, { goal, tool, compact: String(compact).toLowerCase() === 'true' }),
-        },
-      }],
-    })
+    async ({ goal, tool, compact }) => {
+      const snapshot = createProjectSnapshot(projectRoot, getSnapshotOptionsForPrompt('start', compact));
+      return {
+        messages: [{
+          role: 'user',
+          content: {
+            type: 'text',
+            text: buildStartWorkPrompt(projectRoot, { goal, tool, compact: String(compact).toLowerCase() === 'true' }, snapshot),
+          },
+        }],
+      };
+    }
   );
 
   server.registerPrompt(
@@ -237,15 +242,18 @@ function createMCPServer(projectRoot) {
         compact: z.string().optional().describe('Set to "true" for a shorter prompt body'),
       },
     },
-    async ({ compact }) => ({
-      messages: [{
-        role: 'user',
-        content: {
-          type: 'text',
-          text: buildResumeWorkPrompt(projectRoot, { compact: String(compact).toLowerCase() === 'true' }),
-        },
-      }],
-    })
+    async ({ compact }) => {
+      const snapshot = createProjectSnapshot(projectRoot, getSnapshotOptionsForPrompt('resume', compact));
+      return {
+        messages: [{
+          role: 'user',
+          content: {
+            type: 'text',
+            text: buildResumeWorkPrompt(projectRoot, { compact: String(compact).toLowerCase() === 'true' }, snapshot),
+          },
+        }],
+      };
+    }
   );
 
   server.registerPrompt(
@@ -257,15 +265,18 @@ function createMCPServer(projectRoot) {
         audience: z.string().optional().describe('Optional recipient or tool name'),
       },
     },
-    async ({ audience }) => ({
-      messages: [{
-        role: 'user',
-        content: {
-          type: 'text',
-          text: buildHandoffPrompt(projectRoot, { audience }),
-        },
-      }],
-    })
+    async ({ audience }) => {
+      const snapshot = createProjectSnapshot(projectRoot, getSnapshotOptionsForPrompt('handoff'));
+      return {
+        messages: [{
+          role: 'user',
+          content: {
+            type: 'text',
+            text: buildHandoffPrompt(projectRoot, { audience }, snapshot),
+          },
+        }],
+      };
+    }
   );
 
   server.registerPrompt(
@@ -277,15 +288,18 @@ function createMCPServer(projectRoot) {
         focus: z.string().optional().describe('Optional area to focus on, such as auth or database'),
       },
     },
-    async ({ focus }) => ({
-      messages: [{
-        role: 'user',
-        content: {
-          type: 'text',
-          text: buildConflictReviewPrompt(projectRoot, { focus }),
-        },
-      }],
-    })
+    async ({ focus }) => {
+      const snapshot = createProjectSnapshot(projectRoot, getSnapshotOptionsForPrompt('conflicts'));
+      return {
+        messages: [{
+          role: 'user',
+          content: {
+            type: 'text',
+            text: buildConflictReviewPrompt(projectRoot, { focus }, snapshot),
+          },
+        }],
+      };
+    }
   );
 
   return server;
@@ -444,9 +458,9 @@ function getContext(projectRoot, focus, compact, snapshot = null) {
     };
   }
 
-  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
+  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, getSnapshotOptionsForContext(focus, compact));
   const state = currentSnapshot.state;
-  const liveData = snapshotToLiveData(currentSnapshot);
+  const liveData = snapshotToLiveData(currentSnapshot, getLiveDataOptionsForContext(focus, compact));
 
   if (compact) {
     const compactText = buildCompactNarrative(state, liveData);
@@ -790,16 +804,16 @@ function renderContextText(projectRoot, focus = 'all', compact = false, snapshot
 }
 
 function readStableResource(projectRoot, kind, snapshot = null) {
-  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
+  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, getSnapshotOptionsForResource(kind));
   const state = currentSnapshot.state;
-  const liveData = snapshotToLiveData(currentSnapshot);
+  const liveData = snapshotToLiveData(currentSnapshot, getLiveDataOptionsForResource(kind));
   const memory = currentSnapshot.memory;
   const handoffPath = path.join(projectRoot, 'HANDOFF.md');
   const handoffText = fs.existsSync(handoffPath) ? fs.readFileSync(handoffPath, 'utf-8') : renderContextText(projectRoot, 'all', false, currentSnapshot);
 
   switch (kind) {
     case 'context':
-      return buildTextResource('mindswap://context/current', renderContextText(projectRoot, 'all', false));
+      return buildTextResource('mindswap://context/current', renderContextText(projectRoot, 'all', false, currentSnapshot));
     case 'state':
       return buildJsonResource('mindswap://state/current', state);
     case 'decisions':
@@ -890,7 +904,7 @@ function buildStartWorkPrompt(projectRoot, { goal, tool, compact } = {}, snapsho
 }
 
 function buildResumeWorkPrompt(projectRoot, { compact } = {}, snapshot = null) {
-  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
+  const currentSnapshot = snapshot || createProjectSnapshot(projectRoot, getSnapshotOptionsForPrompt('resume', compact));
   const briefing = buildResumeBriefing(currentSnapshot.state, gatherResumeData(projectRoot, currentSnapshot), { compact });
   const lines = [
     'Resume this workstream from the current repo state.',
@@ -1052,19 +1066,20 @@ function manageMemory(projectRoot, opts = {}) {
 // ═══════════════════════════════════════════════════
 
 function gatherLiveData(projectRoot) {
-  return snapshotToLiveData(createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 }));
+  return snapshotToLiveData(createProjectSnapshot(projectRoot, getSnapshotOptionsForContext('all', false)), getLiveDataOptionsForContext('all', false));
 }
 
-function snapshotToLiveData(snapshot) {
+function snapshotToLiveData(snapshot, opts = {}) {
   return {
     branch: snapshot.branch,
     changedFiles: snapshot.changedFiles,
     recentCommits: snapshot.recentCommits,
     decisions: snapshot.decisions,
     history: snapshot.history,
-    nativeSessions: snapshot.nativeSessions,
+    nativeSessions: opts.includeNativeSessions === false ? [] : snapshot.nativeSessions,
     structuredMemory: snapshot.memory?.items || [],
-    guardrails: snapshot.guardrails,
+    importedSessions: opts.includeImportedSessions === false ? [] : snapshot.importedSessions,
+    guardrails: opts.includeGuardrails === false ? null : snapshot.guardrails,
   };
 }
 
@@ -1120,6 +1135,166 @@ function findLooseMatch(token, haystack) {
     token.replace(/tion$/, 't'),
   ].filter(Boolean);
   return variants.some(v => v !== token && v.length >= 3 && haystack.includes(v));
+}
+
+function getSnapshotOptionsForContext(focus, compact) {
+  const base = { historyLimit: 20, recentCommitLimit: 5 };
+  if (compact || focus === 'task') {
+    return {
+      ...base,
+      includeNativeSessions: false,
+      includeImportedSessions: false,
+      includeGuardrails: false,
+    };
+  }
+  if (focus === 'recent') {
+    return {
+      ...base,
+      includeNativeSessions: true,
+      includeImportedSessions: false,
+      includeGuardrails: false,
+    };
+  }
+  if (focus === 'decisions') {
+    return {
+      ...base,
+      includeNativeSessions: false,
+      includeImportedSessions: false,
+      includeGuardrails: true,
+    };
+  }
+  return {
+    ...base,
+    includeNativeSessions: true,
+    includeImportedSessions: true,
+    includeGuardrails: true,
+  };
+}
+
+function getLiveDataOptionsForContext(focus, compact) {
+  if (compact || focus === 'task') {
+    return {
+      includeNativeSessions: false,
+      includeImportedSessions: false,
+      includeGuardrails: false,
+    };
+  }
+  if (focus === 'recent') {
+    return {
+      includeNativeSessions: true,
+      includeImportedSessions: false,
+      includeGuardrails: false,
+    };
+  }
+  if (focus === 'decisions') {
+    return {
+      includeNativeSessions: false,
+      includeImportedSessions: false,
+      includeGuardrails: true,
+    };
+  }
+  return {
+    includeNativeSessions: true,
+    includeImportedSessions: true,
+    includeGuardrails: true,
+  };
+}
+
+function getSnapshotOptionsForSearch(type) {
+  const base = { historyLimit: 50, recentCommitLimit: 5 };
+  if (type === 'decisions' || type === 'history') {
+    return {
+      ...base,
+      includeNativeSessions: false,
+      includeImportedSessions: false,
+      includeGuardrails: false,
+    };
+  }
+  return {
+    ...base,
+    includeNativeSessions: true,
+    includeImportedSessions: true,
+    includeGuardrails: false,
+  };
+}
+
+function getSnapshotOptionsForResource(kind) {
+  const base = { historyLimit: 20, recentCommitLimit: 5 };
+  switch (kind) {
+    case 'context':
+    case 'handoff':
+      return {
+        ...base,
+        includeNativeSessions: true,
+        includeImportedSessions: true,
+        includeGuardrails: true,
+      };
+    case 'decisions':
+      return {
+        ...base,
+        includeNativeSessions: false,
+        includeImportedSessions: false,
+        includeGuardrails: false,
+      };
+    case 'state':
+    case 'memory':
+    default:
+      return {
+        ...base,
+        includeNativeSessions: false,
+        includeImportedSessions: false,
+        includeGuardrails: false,
+      };
+  }
+}
+
+function getLiveDataOptionsForResource(kind) {
+  switch (kind) {
+    case 'context':
+    case 'handoff':
+      return {
+        includeNativeSessions: true,
+        includeImportedSessions: true,
+        includeGuardrails: true,
+      };
+    default:
+      return {
+        includeNativeSessions: false,
+        includeImportedSessions: false,
+        includeGuardrails: false,
+      };
+  }
+}
+
+function getSnapshotOptionsForPrompt(kind, compact) {
+  if (kind === 'conflicts') {
+    return {
+      historyLimit: 20,
+      recentCommitLimit: 5,
+      includeNativeSessions: false,
+      includeImportedSessions: false,
+      includeGuardrails: true,
+    };
+  }
+  if (kind === 'resume') {
+    return {
+      historyLimit: 20,
+      recentCommitLimit: 5,
+      includeNativeSessions: true,
+      includeImportedSessions: true,
+      includeGuardrails: true,
+    };
+  }
+  if (kind === 'start') {
+    return getSnapshotOptionsForContext('all', String(compact).toLowerCase() === 'true');
+  }
+  return {
+    historyLimit: 20,
+    recentCommitLimit: 5,
+    includeNativeSessions: true,
+    includeImportedSessions: true,
+    includeGuardrails: true,
+  };
 }
 
 const QUERY_ALIASES = {

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -698,9 +698,10 @@ function searchContext(projectRoot, query, type, snapshot = null) {
     for (const line of currentSnapshot.decisions) {
       addScoredResult(results, seen, {
         type: 'decision',
-        content: line,
+        content: createSearchSnippet(stripDecisionPrefix(line), queryTokens),
         source: 'decisions.log',
-      }, queryTokens, 1.2);
+        key: line,
+      }, queryTokens, 1.4, line, 4);
     }
   }
 
@@ -709,9 +710,10 @@ function searchContext(projectRoot, query, type, snapshot = null) {
     for (const entry of currentSnapshot.history) {
       addScoredResult(results, seen, {
         type: 'history',
-        content: `[${entry.timestamp}] ${entry.message}${entry.ai_tool ? ` (${entry.ai_tool})` : ''}`,
+        content: createSearchSnippet(entry.message, queryTokens),
         source: 'history',
-      }, queryTokens, 1.0, JSON.stringify(entry));
+        key: JSON.stringify(entry),
+      }, queryTokens, 1.1, JSON.stringify(entry), 2);
     }
   }
 
@@ -720,32 +722,36 @@ function searchContext(projectRoot, query, type, snapshot = null) {
     for (const item of listMemoryItemsFromSnapshot(currentSnapshot, { limit: 50 })) {
       addScoredResult(results, seen, {
         type: `memory:${item.type}`,
-        content: `${item.type}: ${item.message} [${item.status}]`,
+        content: createSearchSnippet(`${item.type}: ${item.message}`, queryTokens),
         source: 'memory',
-      }, queryTokens, item.status === 'open' ? 1.15 : 1.0, `${item.type} ${item.tag} ${item.status} ${item.message}`);
+        key: item.id || `${item.type}:${item.tag}:${item.message}`,
+      }, queryTokens, item.status === 'open' ? 1.4 : 1.0, `${item.type} ${item.tag} ${item.status} ${item.message}`, item.status === 'open' ? 3 : 1);
     }
 
     const state = currentSnapshot.state;
     if (state.current_task?.description) {
       addScoredResult(results, seen, {
         type: 'task',
-        content: `Current task: ${state.current_task.description} [${state.current_task.status}]`,
+        content: createSearchSnippet(`Current task: ${state.current_task.description}`, queryTokens),
         source: 'state.current_task',
-      }, queryTokens, 1.35, state.current_task.description);
+        key: state.current_task.description,
+      }, queryTokens, 1.8, state.current_task.description, 5);
     }
     if (state.project?.tech_stack?.length) {
       addScoredResult(results, seen, {
         type: 'project',
-        content: `Tech stack includes: ${state.project.tech_stack.join(', ')}`,
+        content: createSearchSnippet(`Tech stack: ${state.project.tech_stack.join(', ')}`, queryTokens),
         source: 'state.project',
-      }, queryTokens, 0.9, state.project.tech_stack.join(' '));
+        key: state.project.tech_stack.join(' '),
+      }, queryTokens, 0.8, state.project.tech_stack.join(' '), 1);
     }
     if (state.current_task?.blocker) {
       addScoredResult(results, seen, {
         type: 'blocker',
-        content: `Current blocker: ${state.current_task.blocker}`,
+        content: createSearchSnippet(`Current blocker: ${state.current_task.blocker}`, queryTokens),
         source: 'state.current_task',
-      }, queryTokens, 1.15, state.current_task.blocker);
+        key: state.current_task.blocker,
+      }, queryTokens, 1.7, state.current_task.blocker, 4);
     }
   }
 
@@ -761,9 +767,10 @@ function searchContext(projectRoot, query, type, snapshot = null) {
       ].filter(Boolean).join(' ');
       addScoredResult(results, seen, {
         type: 'native-session',
-        content: `${session.tool}${session.timestamp ? ` @ ${session.timestamp}` : ''}: ${session.summary || 'session context'}`,
+        content: createSearchSnippet(`${session.tool}: ${session.summary || 'session context'}`, queryTokens),
         source: session.tool,
-      }, queryTokens, 0.9, combined || session.rawText || session.tool);
+        key: `${session.tool}:${session.timestamp || ''}:${session.summary || session.rawText || ''}`,
+      }, queryTokens, 0.85, combined || session.rawText || session.tool, 0);
     }
 
     for (const session of currentSnapshot.importedSessions) {
@@ -771,9 +778,10 @@ function searchContext(projectRoot, query, type, snapshot = null) {
       const combined = [...(session.decisions || []), ...(session.context || [])].join(' ');
       addScoredResult(results, seen, {
         type: 'imported',
-        content: `${sourceLabel}: ${(session.context || session.decisions || []).slice(0, 3).join(' | ')}`,
+        content: createSearchSnippet(`${sourceLabel}: ${(session.context || session.decisions || []).slice(0, 3).join(' | ')}`, queryTokens),
         source: sourceLabel,
-      }, queryTokens, 0.8, combined);
+        key: `${sourceLabel}:${(session.context || session.decisions || []).join(' | ')}`,
+      }, queryTokens, 0.75, combined, 0);
     }
   }
 
@@ -787,7 +795,7 @@ function searchContext(projectRoot, query, type, snapshot = null) {
   }
 
   const topResults = results
-    .sort((a, b) => b.score - a.score)
+    .sort((a, b) => (b.rank - a.rank) || (b.score - a.score))
     .slice(0, 15);
   const formatted = topResults.map(r => `[${r.type}] (${Math.round(r.score)}) ${r.content}`).join('\n');
   return {
@@ -1100,14 +1108,14 @@ function tokenize(query) {
   return [...expanded];
 }
 
-function addScoredResult(results, seen, entry, queryTokens, weight, haystackText = '') {
+function addScoredResult(results, seen, entry, queryTokens, weight, haystackText = '', rank = 0) {
   const text = haystackText || entry.content || '';
   const score = scoreText(text, queryTokens, weight);
   if (score <= 0) return;
-  const key = `${entry.type}::${entry.content}`;
+  const key = `${entry.type}::${entry.key || entry.content}`;
   if (seen.has(key)) return;
   seen.add(key);
-  results.push({ ...entry, score });
+  results.push({ ...entry, score, rank: entry.rank ?? rank ?? 0 });
 }
 
 function scoreText(text, queryTokens, weight = 1) {
@@ -1135,6 +1143,36 @@ function findLooseMatch(token, haystack) {
     token.replace(/tion$/, 't'),
   ].filter(Boolean);
   return variants.some(v => v !== token && v.length >= 3 && haystack.includes(v));
+}
+
+function stripDecisionPrefix(line) {
+  return String(line || '').replace(/^\[.*?\]\s*\[.*?\]\s*/, '').trim();
+}
+
+function createSearchSnippet(text, queryTokens, maxLength = 140) {
+  const clean = String(text || '').replace(/\s+/g, ' ').trim();
+  if (!clean) return '';
+  if (!queryTokens || queryTokens.length === 0) return clean.slice(0, maxLength);
+
+  const lower = clean.toLowerCase();
+  let index = -1;
+  for (const token of queryTokens) {
+    const candidate = lower.indexOf(token);
+    if (candidate >= 0 && (index < 0 || candidate < index)) {
+      index = candidate;
+    }
+  }
+
+  if (index < 0) {
+    return clean.length > maxLength ? `${clean.slice(0, maxLength - 1)}…` : clean;
+  }
+
+  const start = Math.max(0, index - 40);
+  const end = Math.min(clean.length, index + 100);
+  const prefix = start > 0 ? '…' : '';
+  const suffix = end < clean.length ? '…' : '';
+  const snippet = clean.slice(start, end);
+  return `${prefix}${snippet}${suffix}`;
 }
 
 function getSnapshotOptionsForContext(focus, compact) {

--- a/src/memory.js
+++ b/src/memory.js
@@ -19,6 +19,7 @@ function getDefaultMemory() {
 
 function ensureMemory(projectRoot) {
   const memoryPath = getMemoryPath(projectRoot);
+  fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
   if (!fs.existsSync(memoryPath)) {
     fs.writeFileSync(memoryPath, JSON.stringify(getDefaultMemory(), null, 2), 'utf-8');
   }

--- a/src/project-snapshot.js
+++ b/src/project-snapshot.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const { isGitRepo, getCurrentBranch, getAllChangedFiles, getRecentCommits } = require('./git');
+const { readState, getHistory } = require('./state');
+const { readMemory } = require('./memory');
+const { parseNativeSessions } = require('./session-parser');
+const { importSessions } = require('./session-import');
+const { analyzeGuardrails } = require('./guardrails');
+
+function createProjectSnapshot(projectRoot, opts = {}) {
+  const gitRepo = isGitRepo(projectRoot);
+  const changedFiles = gitRepo ? getAllChangedFiles(projectRoot) : [];
+  const branch = gitRepo ? getCurrentBranch(projectRoot) : null;
+  const state = readState(projectRoot);
+  const history = getHistory(projectRoot, opts.historyLimit || 20);
+  const recentCommits = gitRepo ? getRecentCommits(projectRoot, opts.recentCommitLimit || 5) : [];
+  const memory = readMemory(projectRoot);
+  const decisions = readDecisionLines(projectRoot);
+  const nativeSessions = parseNativeSessions(projectRoot) || [];
+  const importedSessions = importSessions(projectRoot) || [];
+  const guardrails = analyzeGuardrails(projectRoot, {
+    changedFiles,
+    diffContent: '',
+  });
+
+  return {
+    projectRoot,
+    gitRepo,
+    branch,
+    changedFiles,
+    recentCommits,
+    state,
+    history,
+    memory,
+    decisions,
+    nativeSessions,
+    importedSessions,
+    guardrails,
+  };
+}
+
+function readDecisionLines(projectRoot) {
+  const decisionsPath = path.join(projectRoot, '.mindswap', 'decisions.log');
+  if (!fs.existsSync(decisionsPath)) return [];
+  return fs.readFileSync(decisionsPath, 'utf-8')
+    .split('\n')
+    .filter(line => line.startsWith('['));
+}
+
+module.exports = {
+  createProjectSnapshot,
+  readDecisionLines,
+};

--- a/src/project-snapshot.js
+++ b/src/project-snapshot.js
@@ -35,12 +35,16 @@ function createProjectSnapshot(projectRoot, opts = {}) {
     decisions,
   };
 
-  defineLazyProperty(snapshot, 'nativeSessions', () => parseNativeSessions(projectRoot) || []);
-  defineLazyProperty(snapshot, 'importedSessions', () => importSessions(projectRoot) || []);
-  defineLazyProperty(snapshot, 'guardrails', () => analyzeGuardrails(projectRoot, {
+  const includeNativeSessions = opts.includeNativeSessions !== false;
+  const includeImportedSessions = opts.includeImportedSessions !== false;
+  const includeGuardrails = opts.includeGuardrails !== false;
+
+  defineLazyProperty(snapshot, 'nativeSessions', includeNativeSessions ? () => parseNativeSessions(projectRoot) || [] : () => []);
+  defineLazyProperty(snapshot, 'importedSessions', includeImportedSessions ? () => importSessions(projectRoot) || [] : () => []);
+  defineLazyProperty(snapshot, 'guardrails', includeGuardrails ? () => analyzeGuardrails(projectRoot, {
     changedFiles,
     diffContent: '',
-  }));
+  }) : () => ({ warnings: [], surface: [], decisionLines: [] }));
 
   snapshotCache.set(signature, snapshot);
   return snapshot;
@@ -59,6 +63,9 @@ function buildSnapshotSignature(projectRoot, opts = {}) {
     projectRoot,
     String(opts.historyLimit || 20),
     String(opts.recentCommitLimit || 5),
+    String(opts.includeNativeSessions !== false),
+    String(opts.includeImportedSessions !== false),
+    String(opts.includeGuardrails !== false),
     fileSignature(path.join(projectRoot, '.mindswap', 'state.json')),
     dirSignature(path.join(projectRoot, '.mindswap', 'history')),
     fileSignature(path.join(projectRoot, '.mindswap', 'memory.json')),

--- a/src/project-snapshot.js
+++ b/src/project-snapshot.js
@@ -7,7 +7,13 @@ const { parseNativeSessions } = require('./session-parser');
 const { importSessions } = require('./session-import');
 const { analyzeGuardrails } = require('./guardrails');
 
+const snapshotCache = new Map();
+
 function createProjectSnapshot(projectRoot, opts = {}) {
+  const signature = buildSnapshotSignature(projectRoot, opts);
+  const cached = snapshotCache.get(signature);
+  if (cached) return cached;
+
   const gitRepo = isGitRepo(projectRoot);
   const changedFiles = gitRepo ? getAllChangedFiles(projectRoot) : [];
   const branch = gitRepo ? getCurrentBranch(projectRoot) : null;
@@ -16,14 +22,8 @@ function createProjectSnapshot(projectRoot, opts = {}) {
   const recentCommits = gitRepo ? getRecentCommits(projectRoot, opts.recentCommitLimit || 5) : [];
   const memory = readMemory(projectRoot);
   const decisions = readDecisionLines(projectRoot);
-  const nativeSessions = parseNativeSessions(projectRoot) || [];
-  const importedSessions = importSessions(projectRoot) || [];
-  const guardrails = analyzeGuardrails(projectRoot, {
-    changedFiles,
-    diffContent: '',
-  });
 
-  return {
+  const snapshot = {
     projectRoot,
     gitRepo,
     branch,
@@ -33,10 +33,17 @@ function createProjectSnapshot(projectRoot, opts = {}) {
     history,
     memory,
     decisions,
-    nativeSessions,
-    importedSessions,
-    guardrails,
   };
+
+  defineLazyProperty(snapshot, 'nativeSessions', () => parseNativeSessions(projectRoot) || []);
+  defineLazyProperty(snapshot, 'importedSessions', () => importSessions(projectRoot) || []);
+  defineLazyProperty(snapshot, 'guardrails', () => analyzeGuardrails(projectRoot, {
+    changedFiles,
+    diffContent: '',
+  }));
+
+  snapshotCache.set(signature, snapshot);
+  return snapshot;
 }
 
 function readDecisionLines(projectRoot) {
@@ -45,6 +52,69 @@ function readDecisionLines(projectRoot) {
   return fs.readFileSync(decisionsPath, 'utf-8')
     .split('\n')
     .filter(line => line.startsWith('['));
+}
+
+function buildSnapshotSignature(projectRoot, opts = {}) {
+  const parts = [
+    projectRoot,
+    String(opts.historyLimit || 20),
+    String(opts.recentCommitLimit || 5),
+    fileSignature(path.join(projectRoot, '.mindswap', 'state.json')),
+    dirSignature(path.join(projectRoot, '.mindswap', 'history')),
+    fileSignature(path.join(projectRoot, '.mindswap', 'memory.json')),
+    fileSignature(path.join(projectRoot, '.mindswap', 'decisions.log')),
+    dirSignature(path.join(projectRoot, '.claude')),
+    dirSignature(path.join(projectRoot, '.claude', 'projects')),
+    dirSignature(path.join(projectRoot, '.cursor')),
+    dirSignature(path.join(projectRoot, '.cursor', 'rules')),
+    fileSignature(path.join(projectRoot, '.aider.conf.yml')),
+    fileSignature(path.join(projectRoot, 'CONVENTIONS.md')),
+    fileSignature(path.join(projectRoot, 'CLAUDE.md')),
+    fileSignature(path.join(projectRoot, 'CODEX.md')),
+    fileSignature(path.join(projectRoot, 'AGENTS.md')),
+    fileSignature(path.join(projectRoot, 'HANDOFF.md')),
+    dirSignature(path.join(projectRoot, '.amp')),
+    dirSignature(path.join(projectRoot, '.cline')),
+    dirSignature(path.join(projectRoot, '.roo')),
+  ];
+
+  return parts.join('|');
+}
+
+function fileSignature(filePath) {
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) return 'f:na';
+    return `f:${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return 'f:missing';
+  }
+}
+
+function dirSignature(dirPath) {
+  try {
+    const stat = fs.statSync(dirPath);
+    if (!stat.isDirectory()) return 'd:na';
+    return `d:${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return 'd:missing';
+  }
+}
+
+function defineLazyProperty(target, key, loader) {
+  let loaded = false;
+  let value;
+  Object.defineProperty(target, key, {
+    enumerable: true,
+    configurable: false,
+    get() {
+      if (!loaded) {
+        value = loader();
+        loaded = true;
+      }
+      return value;
+    },
+  });
 }
 
 module.exports = {

--- a/src/registry.js
+++ b/src/registry.js
@@ -26,7 +26,7 @@ function buildRegistryManifest(packageJson, options = {}) {
     $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
     name,
     title: options.title || humanizeName(packageJson.name),
-    description: options.description || packageJson.description || '',
+    description: options.description || 'Local-first AI context and memory server for cross-tool coding continuity.',
     repository: repositoryUrl ? {
       url: normalizeRepositoryUrl(repositoryUrl),
       source: 'github',
@@ -39,6 +39,10 @@ function buildRegistryManifest(packageJson, options = {}) {
       transport: {
         type: 'stdio',
       },
+      packageArguments: [{
+        type: 'positional',
+        value: 'mcp',
+      }],
     }],
   };
 

--- a/src/reindex.js
+++ b/src/reindex.js
@@ -1,0 +1,28 @@
+const chalk = require('chalk');
+const { rebuildSearchIndex, isSqliteAvailable } = require('./index-store');
+
+async function reindex(projectRoot, opts = {}) {
+  const report = rebuildSearchIndex(projectRoot, opts);
+
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return report;
+  }
+
+  console.log(chalk.bold('\n⚡ Reindex\n'));
+  if (!isSqliteAvailable()) {
+    console.log(chalk.yellow('  SQLite indexing is not available in this Node.js runtime.'));
+    console.log();
+    return report;
+  }
+
+  console.log(chalk.green(`  Indexed ${report.indexed} searchable record${report.indexed === 1 ? '' : 's'}`));
+  console.log(chalk.dim(`  Scope: ${report.scope}`));
+  console.log(chalk.dim(`  DB: ${report.db_path}`));
+  console.log();
+  return report;
+}
+
+module.exports = {
+  reindex,
+};

--- a/src/resume.js
+++ b/src/resume.js
@@ -1,12 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
-const { readState, getDataDir, getHistory } = require('./state');
-const { isGitRepo, getCurrentBranch, getAllChangedFiles, getRecentCommits } = require('./git');
+const { readState, getDataDir } = require('./state');
 const { findAllConflicts, checkDepsVsDecisions } = require('./conflicts');
 const { calculateQualityScore } = require('./narrative');
-const { getOpenMemoryItems, getRecentMemoryItems } = require('./memory');
-const { parseNativeSessions } = require('./session-parser');
+const { createProjectSnapshot } = require('./project-snapshot');
 
 async function resume(projectRoot, opts = {}) {
   const dataDir = getDataDir(projectRoot);
@@ -15,8 +13,9 @@ async function resume(projectRoot, opts = {}) {
     return;
   }
 
-  const state = readState(projectRoot);
-  const live = gatherResumeData(projectRoot);
+  const snapshot = createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
+  const state = snapshot.state;
+  const live = gatherResumeData(projectRoot, snapshot);
   const briefing = buildResumeBriefing(state, live, opts);
 
   if (opts.json) {
@@ -43,16 +42,17 @@ async function resume(projectRoot, opts = {}) {
   console.log();
 }
 
-function gatherResumeData(projectRoot) {
-  const branch = isGitRepo(projectRoot) ? getCurrentBranch(projectRoot) : null;
-  const changedFiles = isGitRepo(projectRoot) ? getAllChangedFiles(projectRoot) : [];
-  const recentCommits = isGitRepo(projectRoot) ? getRecentCommits(projectRoot, 5) : [];
-  const history = getHistory(projectRoot, 10);
-  const nativeSessions = parseNativeSessions(projectRoot);
-  const decisions = readDecisions(projectRoot);
-  const structuredMemory = getRecentMemoryItems(projectRoot, 20);
-  const blockers = getOpenMemoryItems(projectRoot, 'blocker', 5);
-  const questions = getOpenMemoryItems(projectRoot, 'question', 5);
+function gatherResumeData(projectRoot, snapshot = null) {
+  const liveSnapshot = snapshot || createProjectSnapshot(projectRoot, { historyLimit: 20, recentCommitLimit: 5 });
+  const branch = liveSnapshot.branch;
+  const changedFiles = liveSnapshot.changedFiles;
+  const recentCommits = liveSnapshot.recentCommits;
+  const history = liveSnapshot.history || [];
+  const nativeSessions = liveSnapshot.nativeSessions || [];
+  const decisions = liveSnapshot.decisions || readDecisions(projectRoot);
+  const structuredMemory = Array.isArray(liveSnapshot.memory?.items) ? liveSnapshot.memory.items.slice(-20) : [];
+  const blockers = structuredMemory.filter(item => item.type === 'blocker' && item.status === 'open').slice(-5);
+  const questions = structuredMemory.filter(item => item.type === 'question' && item.status === 'open').slice(-5);
   const conflicts = findAllConflicts(projectRoot);
   const depConflicts = checkDepsVsDecisions(projectRoot);
 

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const os = require('os');
+const { getDataDir } = require('./state');
+
+function getGlobalProjectRoot() {
+  return os.homedir();
+}
+
+function normalizeScope(opts = {}) {
+  if (opts.scope) return String(opts.scope).toLowerCase();
+  if (opts.global) return 'global';
+  return 'repo';
+}
+
+function resolveMemoryRoots(projectRoot, opts = {}) {
+  const scope = normalizeScope(opts);
+  if (scope === 'global') return [getGlobalProjectRoot()];
+  if (scope === 'all') return [projectRoot, getGlobalProjectRoot()];
+  return [projectRoot];
+}
+
+function canUseRepoScope(projectRoot) {
+  return fs.existsSync(getDataDir(projectRoot));
+}
+
+module.exports = {
+  getGlobalProjectRoot,
+  normalizeScope,
+  resolveMemoryRoots,
+  canUseRepoScope,
+};

--- a/test/ask.test.js
+++ b/test/ask.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { spawnSync } = require('child_process');
 const { createTempProject, cleanup } = require('./helpers');
 const { ensureDataDir, getDefaultState, writeState, readState } = require('../src/state');
 const { appendMemoryItem } = require('../src/memory');
@@ -123,6 +124,23 @@ exports.test_ask_scope_all_can_recall_global_memory = async () => {
     } finally {
       console.log = originalLog;
     }
+  } finally {
+    teardown();
+  }
+};
+
+exports.test_cli_search_returns_raw_context_matches = () => {
+  setup();
+  try {
+    const result = spawnSync('node', ['/Users/zopdev/mindswap/bin/mindswap.js', 'search', 'jwt', '--json'], {
+      cwd: dir,
+      encoding: 'utf-8',
+    });
+
+    assert.strictEqual(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.ok(payload.text.includes('JWT over sessions'));
+    assert.ok(payload.text.includes('result(s)'));
   } finally {
     teardown();
   }

--- a/test/ask.test.js
+++ b/test/ask.test.js
@@ -1,15 +1,19 @@
 const assert = require('assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { createTempProject, cleanup } = require('./helpers');
 const { ensureDataDir, getDefaultState, writeState, readState } = require('../src/state');
+const { appendMemoryItem } = require('../src/memory');
 const { ask, parseSearchResults, buildAnswerPayload } = require('../src/ask');
 
 let dir;
+const globalDir = path.join(os.homedir(), '.mindswap');
 
 function setup() {
   dir = createTempProject('ask-test');
   ensureDataDir(dir);
+  try { fs.rmSync(globalDir, { recursive: true, force: true }); } catch {}
 
   const state = getDefaultState();
   state.project = {
@@ -42,6 +46,7 @@ function setup() {
 
 function teardown() {
   cleanup(dir);
+  try { fs.rmSync(globalDir, { recursive: true, force: true }); } catch {}
 }
 
 exports.test_parseSearchResults_extracts_ranked_items = () => {
@@ -89,6 +94,32 @@ exports.test_ask_outputs_text_and_json = async () => {
       const parsed = JSON.parse(lines.join('\n'));
       assert.ok(parsed.answer.includes('JWT'));
       assert.ok(Array.isArray(parsed.sources));
+    } finally {
+      console.log = originalLog;
+    }
+  } finally {
+    teardown();
+  }
+};
+
+exports.test_ask_scope_all_can_recall_global_memory = async () => {
+  setup();
+  try {
+    appendMemoryItem(os.homedir(), {
+      type: 'assumption',
+      tag: 'style',
+      message: 'Prefer direct explanations across tools',
+    });
+
+    const originalLog = console.log;
+    const lines = [];
+    console.log = (...args) => {
+      lines.push(args.join(' '));
+    };
+
+    try {
+      await ask(dir, 'what explanation style should we use?', { scope: 'all' });
+      assert.ok(lines.join('\n').includes('Prefer direct explanations across tools'));
     } finally {
       console.log = originalLog;
     }

--- a/test/index-store.test.js
+++ b/test/index-store.test.js
@@ -1,0 +1,96 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createTempProject, cleanup } = require('./helpers');
+const { ensureDataDir, getDefaultState, writeState, addToHistory } = require('../src/state');
+const { appendMemoryItem } = require('../src/memory');
+const {
+  isSqliteAvailable,
+  getIndexDbPath,
+  rebuildSearchIndex,
+  searchIndexedEntries,
+} = require('../src/index-store');
+
+let dir;
+const globalDir = path.join(os.homedir(), '.mindswap');
+
+function setup() {
+  dir = createTempProject('index-store-test');
+  ensureDataDir(dir);
+  try { fs.rmSync(globalDir, { recursive: true, force: true }); } catch {}
+
+  const state = getDefaultState();
+  state.project = {
+    name: 'index-app',
+    language: 'typescript',
+    framework: 'Express',
+    tech_stack: ['node.js', 'express', 'sqlite'],
+    package_manager: 'npm',
+  };
+  state.current_task = {
+    description: 'improve context indexing',
+    status: 'in_progress',
+    blocker: 'keep search fast',
+    next_steps: ['index repo and global memory'],
+    started_at: '2026-05-01T00:00:00.000Z',
+  };
+  writeState(dir, state);
+
+  fs.writeFileSync(path.join(dir, '.mindswap', 'decisions.log'), [
+    '[2026-05-01T00:00:00Z] [search] prefer local indexing over cloud search',
+  ].join('\n') + '\n', 'utf-8');
+
+  addToHistory(dir, {
+    timestamp: '2026-05-01T01:00:00.000Z',
+    message: 'added repo search ranking',
+    ai_tool: 'Codex',
+  });
+
+  appendMemoryItem(dir, {
+    type: 'assumption',
+    tag: 'search',
+    message: 'Repo memory should outrank unrelated personal memory',
+  });
+
+  appendMemoryItem(os.homedir(), {
+    type: 'assumption',
+    tag: 'style',
+    message: 'Prefer concise answers across AI tools',
+  });
+}
+
+function teardown() {
+  cleanup(dir);
+  try { fs.rmSync(globalDir, { recursive: true, force: true }); } catch {}
+}
+
+exports.test_rebuildSearchIndex_creates_sqlite_db = () => {
+  if (!isSqliteAvailable()) return;
+  setup();
+  try {
+    const report = rebuildSearchIndex(dir, { scope: 'all' });
+    assert.ok(fs.existsSync(getIndexDbPath(dir)));
+    assert.ok(report.indexed > 0);
+    assert.strictEqual(report.scope, 'all');
+  } finally {
+    teardown();
+  }
+};
+
+exports.test_searchIndexedEntries_returns_repo_and_global_hits = () => {
+  if (!isSqliteAvailable()) return;
+  setup();
+  try {
+    rebuildSearchIndex(dir, { scope: 'all' });
+    const repoHits = searchIndexedEntries(dir, 'local indexing', { scope: 'repo', limit: 10 });
+    assert.ok(repoHits.some(hit => hit.scope === 'repo'));
+    assert.ok(repoHits.some(hit => hit.type === 'decision' || hit.type === 'task'));
+
+    const globalHits = searchIndexedEntries(dir, 'concise answers', { scope: 'global', limit: 10 });
+    assert.ok(globalHits.some(hit => hit.scope === 'global'));
+    assert.ok(globalHits.some(hit => hit.type === 'memory:assumption'));
+  } finally {
+    teardown();
+  }
+};

--- a/test/mcp-http.test.js
+++ b/test/mcp-http.test.js
@@ -119,6 +119,11 @@ exports.test_mcp_http_serve_tools_prompts_resources_and_auth = async () => {
     });
     const toolsPayload = JSON.parse(tools.body);
     assert.ok(toolsPayload.result.tools.some(tool => tool.name === 'mindswap_memory'));
+    const searchTool = toolsPayload.result.tools.find(tool => tool.name === 'mindswap_search');
+    const memoryTool = toolsPayload.result.tools.find(tool => tool.name === 'mindswap_memory');
+    assert.deepStrictEqual(searchTool.inputSchema.properties.scope.enum, ['repo', 'global', 'all']);
+    assert.deepStrictEqual(memoryTool.inputSchema.properties.scope.enum, ['repo', 'global', 'all']);
+    assert.strictEqual(memoryTool.inputSchema.properties.global.type, 'boolean');
 
     const prompts = await requestJson(server.url, {
       method: 'POST',

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -85,6 +85,19 @@ exports.test_searchContext_semantic_ranking_finds_imported_auth_context = () => 
   }
 };
 
+exports.test_searchContext_prioritizes_task_and_blocker_results = () => {
+  setup();
+  try {
+    const result = searchContext(dir, 'login', 'all');
+    const lines = result.content[0].text.split('\n').filter(Boolean);
+    const firstHit = lines.find(line => line.startsWith('['));
+    assert.ok(firstHit.includes('[task]') || firstHit.includes('[blocker]'), 'should prioritize task or blocker results');
+    assert.ok(lines.some(line => line.includes('Current task: implement login flow') || line.includes('Current blocker: waiting on token refresh behavior')));
+  } finally {
+    teardown();
+  }
+};
+
 exports.test_manageMemory_add_list_update_resolve_archive_delete = () => {
   setup();
   try {

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -1,8 +1,11 @@
 const assert = require('assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { createTempProject, cleanup } = require('./helpers');
 const { ensureDataDir, writeState, getDefaultState, addToHistory } = require('../src/state');
+const { readMemory } = require('../src/memory');
+const { getIndexDbPath } = require('../src/index-store');
 const {
   searchContext,
   manageMemory,
@@ -14,10 +17,12 @@ const {
 } = require('../src/mcp-server');
 
 let dir;
+const globalDir = path.join(os.homedir(), '.mindswap');
 
 function setup() {
   dir = createTempProject('mcp-search-test');
   ensureDataDir(dir);
+  try { fs.rmSync(globalDir, { recursive: true, force: true }); } catch {}
 
   const state = getDefaultState();
   state.project = {
@@ -58,6 +63,7 @@ function setup() {
 
 function teardown() {
   cleanup(dir);
+  try { fs.rmSync(globalDir, { recursive: true, force: true }); } catch {}
 }
 
 exports.test_searchContext_semantic_ranking_finds_database_matches = () => {
@@ -155,6 +161,86 @@ exports.test_manageMemory_add_list_update_resolve_archive_delete = () => {
     });
     const delPayload = JSON.parse(del.content[0].text);
     assert.strictEqual(delPayload.deleted, true);
+  } finally {
+    teardown();
+  }
+};
+
+exports.test_manageMemory_add_global_writes_to_home_scope = () => {
+  setup();
+  try {
+    const add = manageMemory(dir, {
+      action: 'add',
+      type: 'assumption',
+      tag: 'style',
+      message: 'Prefer concise answers across AI tools',
+      scope: 'global',
+      json: true,
+    });
+    const addPayload = JSON.parse(add.content[0].text);
+    assert.strictEqual(addPayload.item.type, 'assumption');
+
+    const memory = readMemory(os.homedir());
+    assert.ok(memory.items.some(item => item.message.includes('Prefer concise answers across AI tools')));
+  } finally {
+    teardown();
+  }
+};
+
+exports.test_searchContext_scope_all_includes_global_memory = () => {
+  setup();
+  try {
+    manageMemory(dir, {
+      action: 'add',
+      type: 'assumption',
+      tag: 'style',
+      message: 'Prefer direct explanations across AI tools',
+      scope: 'global',
+      json: true,
+    });
+
+    const result = searchContext(dir, 'direct explanations', 'all', null, { scope: 'all' });
+    const text = result.content[0].text;
+    assert.ok(text.includes('global:assumption'), 'should label global memory results');
+    assert.ok(text.includes('Prefer direct explanations across AI tools'));
+  } finally {
+    teardown();
+  }
+};
+
+exports.test_searchContext_prefers_sqlite_index_when_present = () => {
+  setup();
+  try {
+    // Create a synthetic indexed row that doesn't exist in repo files.
+    let sqlite;
+    try { sqlite = require('node:sqlite'); } catch {}
+    if (!sqlite?.DatabaseSync) return;
+
+    const dbPath = getIndexDbPath(dir);
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    const db = new sqlite.DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS documents (
+          key TEXT PRIMARY KEY,
+          scope TEXT NOT NULL,
+          type TEXT NOT NULL,
+          source TEXT NOT NULL,
+          content TEXT NOT NULL
+        );
+      `);
+      db.prepare(`
+        INSERT OR REPLACE INTO documents (key, scope, type, source, content)
+        VALUES (?, ?, ?, ?, ?)
+      `).run('synthetic:key', 'repo', 'history', 'synthetic', 'SYNTHETIC INDEX ONLY HIT');
+    } finally {
+      db.close();
+    }
+
+    const result = searchContext(dir, 'SYNTHETIC', 'all', null, { scope: 'repo' });
+    const text = result.content[0].text;
+    assert.ok(text.includes('indexed result(s)'), 'should use indexed search when index exists');
+    assert.ok(text.includes('SYNTHETIC INDEX ONLY HIT'));
   } finally {
     teardown();
   }

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const { execFileSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 const { createTempProject, cleanup } = require('./helpers');
 const { ensureDataDir } = require('../src/state');
 const {
@@ -141,6 +141,24 @@ exports.test_cli_memory_add_treats_free_text_as_message = () => {
     const payload = JSON.parse(output.trim());
     assert.strictEqual(payload.item.message, 'Waiting on auth review');
     assert.strictEqual(payload.item.type, 'blocker');
+  } finally {
+    teardown();
+  }
+};
+
+exports.test_cli_json_output_does_not_emit_sqlite_warning = () => {
+  setup();
+  try {
+    execFileSync('node', ['/Users/zopdev/mindswap/bin/mindswap.js', 'init'], { cwd: dir, stdio: 'pipe' });
+    const result = spawnSync('node', ['/Users/zopdev/mindswap/bin/mindswap.js', 'memory', 'list', '--json'], {
+      cwd: dir,
+      encoding: 'utf-8',
+    });
+
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stderr.trim(), '');
+    const payload = JSON.parse(result.stdout);
+    assert.strictEqual(payload.action, 'list');
   } finally {
     teardown();
   }

--- a/test/perf-guardrail.test.js
+++ b/test/perf-guardrail.test.js
@@ -1,0 +1,93 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { performance } = require('perf_hooks');
+const { createTempProject, cleanup } = require('./helpers');
+const { ensureDataDir, getDefaultState, writeState, addToHistory } = require('../src/state');
+const { appendMemoryItem } = require('../src/memory');
+const { createProjectSnapshot } = require('../src/project-snapshot');
+const { searchContext } = require('../src/mcp-server');
+
+let dir;
+
+function setup() {
+  dir = createTempProject('perf-guardrail-test');
+  ensureDataDir(dir);
+
+  const state = getDefaultState();
+  state.project = {
+    name: 'perf-app',
+    language: 'typescript',
+    framework: 'Express',
+    tech_stack: ['node.js', 'express', 'postgres'],
+    package_manager: 'npm',
+  };
+  state.current_task = {
+    description: 'keep the hot path light',
+    status: 'in_progress',
+    blocker: 'watch the repeated reads',
+    next_steps: ['reuse the snapshot cache'],
+    started_at: '2026-04-25T00:00:00.000Z',
+  };
+  writeState(dir, state);
+
+  fs.writeFileSync(path.join(dir, '.mindswap', 'decisions.log'), [
+    '[2026-04-25T00:00:00Z] [perf] reuse repo snapshots',
+    '[2026-04-25T00:00:01Z] [perf] prefer cache hits over repeated reads',
+  ].join('\n') + '\n', 'utf-8');
+
+  addToHistory(dir, {
+    timestamp: '2026-04-25T01:00:00.000Z',
+    message: 'validated cached context reuse',
+    ai_tool: 'Codex',
+  });
+
+  appendMemoryItem(dir, {
+    type: 'blocker',
+    tag: 'perf',
+    message: 'Do not regress the shared snapshot path',
+    status: 'open',
+  });
+}
+
+function teardown() {
+  cleanup(dir);
+}
+
+function benchmark(label, iterations, fn, limitMs) {
+  const startedAt = performance.now();
+  for (let i = 0; i < iterations; i += 1) {
+    fn();
+  }
+  const duration = performance.now() - startedAt;
+  assert.ok(
+    duration <= limitMs,
+    `${label} took ${duration.toFixed(1)}ms for ${iterations} iterations (limit ${limitMs}ms)`
+  );
+}
+
+exports.test_snapshot_cache_and_search_hot_paths_stay_fast = () => {
+  setup();
+  try {
+    const cold = createProjectSnapshot(dir, { historyLimit: 10, recentCommitLimit: 5 });
+    assert.ok(cold.state.project.name === 'perf-app');
+
+    const warmSnapshot = createProjectSnapshot(dir, { historyLimit: 10, recentCommitLimit: 5 });
+
+    benchmark(
+      'snapshot cache reuse',
+      250,
+      () => createProjectSnapshot(dir, { historyLimit: 10, recentCommitLimit: 5 }),
+      400
+    );
+
+    benchmark(
+      'search hot path',
+      60,
+      () => searchContext(dir, 'perf', 'all', warmSnapshot),
+      850
+    );
+  } finally {
+    teardown();
+  }
+};

--- a/test/project-snapshot.test.js
+++ b/test/project-snapshot.test.js
@@ -58,6 +58,23 @@ exports.test_createProjectSnapshot_collects_repo_context_once = () => {
     assert.ok(snapshot.decisions.some(line => line.includes('reduce repeated reads')));
     assert.ok(Array.isArray(snapshot.changedFiles));
     assert.ok(Array.isArray(snapshot.recentCommits));
+
+    const nativeDescriptor = Object.getOwnPropertyDescriptor(snapshot, 'nativeSessions');
+    const importedDescriptor = Object.getOwnPropertyDescriptor(snapshot, 'importedSessions');
+    const guardrailDescriptor = Object.getOwnPropertyDescriptor(snapshot, 'guardrails');
+    assert.strictEqual(typeof nativeDescriptor.get, 'function');
+    assert.strictEqual(typeof importedDescriptor.get, 'function');
+    assert.strictEqual(typeof guardrailDescriptor.get, 'function');
+
+    const snapshotAgain = createProjectSnapshot(dir, { historyLimit: 5, recentCommitLimit: 5 });
+    assert.strictEqual(snapshotAgain, snapshot);
+
+    const state = JSON.parse(fs.readFileSync(path.join(dir, '.mindswap', 'state.json'), 'utf-8'));
+    state.current_task.next_steps.push('verify cache invalidation');
+    writeState(dir, state);
+
+    const snapshotAfterChange = createProjectSnapshot(dir, { historyLimit: 5, recentCommitLimit: 5 });
+    assert.notStrictEqual(snapshotAfterChange, snapshot);
   } finally {
     teardown();
   }

--- a/test/project-snapshot.test.js
+++ b/test/project-snapshot.test.js
@@ -75,6 +75,17 @@ exports.test_createProjectSnapshot_collects_repo_context_once = () => {
 
     const snapshotAfterChange = createProjectSnapshot(dir, { historyLimit: 5, recentCommitLimit: 5 });
     assert.notStrictEqual(snapshotAfterChange, snapshot);
+
+    const lightSnapshot = createProjectSnapshot(dir, {
+      historyLimit: 5,
+      recentCommitLimit: 5,
+      includeNativeSessions: false,
+      includeImportedSessions: false,
+      includeGuardrails: false,
+    });
+    assert.deepStrictEqual(lightSnapshot.nativeSessions, []);
+    assert.deepStrictEqual(lightSnapshot.importedSessions, []);
+    assert.deepStrictEqual(lightSnapshot.guardrails, { warnings: [], surface: [], decisionLines: [] });
   } finally {
     teardown();
   }

--- a/test/project-snapshot.test.js
+++ b/test/project-snapshot.test.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { createTempProject, cleanup } = require('./helpers');
+const { ensureDataDir, getDefaultState, writeState, addToHistory } = require('../src/state');
+const { appendMemoryItem } = require('../src/memory');
+const { createProjectSnapshot } = require('../src/project-snapshot');
+
+let dir;
+
+function setup() {
+  dir = createTempProject('project-snapshot-test');
+  ensureDataDir(dir);
+
+  const state = getDefaultState();
+  state.project = {
+    name: 'snapshot-app',
+    language: 'typescript',
+    framework: 'Express',
+    tech_stack: ['node.js', 'express'],
+    package_manager: 'npm',
+  };
+  state.current_task = {
+    description: 'refine MCP paths',
+    status: 'in_progress',
+    blocker: null,
+    next_steps: ['profile hot paths'],
+    started_at: '2026-04-24T00:00:00.000Z',
+  };
+  writeState(dir, state);
+
+  fs.writeFileSync(path.join(dir, '.mindswap', 'decisions.log'), '[2026-04-24T00:00:00Z] [perf] reduce repeated reads\n', 'utf-8');
+  addToHistory(dir, {
+    timestamp: '2026-04-24T01:00:00.000Z',
+    message: 'profiled mcp paths',
+    ai_tool: 'Codex',
+  });
+  appendMemoryItem(dir, {
+    type: 'blocker',
+    message: 'Need to keep context output small',
+    status: 'open',
+  });
+}
+
+function teardown() {
+  cleanup(dir);
+}
+
+exports.test_createProjectSnapshot_collects_repo_context_once = () => {
+  setup();
+  try {
+    const snapshot = createProjectSnapshot(dir, { historyLimit: 5, recentCommitLimit: 5 });
+    assert.strictEqual(snapshot.state.project.name, 'snapshot-app');
+    assert.ok(Array.isArray(snapshot.history));
+    assert.strictEqual(snapshot.history.length, 1);
+    assert.ok(Array.isArray(snapshot.memory.items));
+    assert.strictEqual(snapshot.memory.items.length, 1);
+    assert.ok(snapshot.decisions.some(line => line.includes('reduce repeated reads')));
+    assert.ok(Array.isArray(snapshot.changedFiles));
+    assert.ok(Array.isArray(snapshot.recentCommits));
+  } finally {
+    teardown();
+  }
+};

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -29,8 +29,12 @@ exports.test_buildRegistryManifest_includes_npm_and_metadata = () => {
     const manifest = buildRegistryManifest(packageJson);
     assert.strictEqual(manifest.name, packageJson.mcpName);
     assert.strictEqual(manifest.version, packageJson.version);
+    assert.ok(manifest.description.length <= 100);
     assert.strictEqual(manifest.packages[0].identifier, packageJson.name);
     assert.strictEqual(manifest.packages[0].transport.type, 'stdio');
+    assert.deepStrictEqual(manifest.packages[0].packageArguments, [
+      { type: 'positional', value: 'mcp' },
+    ]);
   } finally {
     teardown();
   }
@@ -71,7 +75,7 @@ exports.test_registry_cli_outputs_ready_status = () => {
       encoding: 'utf-8',
     });
     const payload = JSON.parse(output.trim());
-    assert.strictEqual(payload.package.mcpName, 'io.github.shiporbleed/mindswap');
+    assert.strictEqual(payload.package.mcpName, 'io.github.ShipOrBleed/mindswap');
     assert.ok(payload.manifest.name.includes('mindswap'));
   } finally {
     teardown();

--- a/test/reindex.test.js
+++ b/test/reindex.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { createTempProject, cleanup } = require('./helpers');
+const { ensureDataDir } = require('../src/state');
+const { appendMemoryItem } = require('../src/memory');
+const { reindex } = require('../src/reindex');
+
+let dir;
+
+function setup() {
+  dir = createTempProject('reindex-test');
+  ensureDataDir(dir);
+  appendMemoryItem(dir, {
+    type: 'assumption',
+    tag: 'search',
+    message: 'Index this memory for search',
+  });
+}
+
+function teardown() {
+  cleanup(dir);
+}
+
+exports.test_reindex_outputs_json_report = async () => {
+  setup();
+  try {
+    const originalLog = console.log;
+    const lines = [];
+    console.log = (...args) => {
+      lines.push(args.join(' '));
+    };
+
+    try {
+      await reindex(dir, { scope: 'repo', json: true });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const payload = JSON.parse(lines.join('\n'));
+    assert.strictEqual(payload.ok, true);
+    assert.strictEqual(payload.scope, 'repo');
+    assert.ok(fs.existsSync(path.join(dir, '.mindswap', 'mindswap.db')));
+  } finally {
+    teardown();
+  }
+};

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+const os = require('os');
+const { createTempProject, cleanup } = require('./helpers');
+const { resolveMemoryRoots, getGlobalProjectRoot, normalizeScope } = require('../src/scope');
+
+let dir;
+
+function setup() {
+  dir = createTempProject('scope-test');
+}
+
+function teardown() {
+  cleanup(dir);
+}
+
+exports.test_getGlobalProjectRoot_uses_home_directory = () => {
+  assert.strictEqual(getGlobalProjectRoot(), os.homedir());
+};
+
+exports.test_normalizeScope_prefers_explicit_scope = () => {
+  assert.strictEqual(normalizeScope({ scope: 'all' }), 'all');
+};
+
+exports.test_normalizeScope_maps_global_flag = () => {
+  assert.strictEqual(normalizeScope({ global: true }), 'global');
+};
+
+exports.test_resolveMemoryRoots_returns_repo_root_by_default_inside_repo = () => {
+  setup();
+  try {
+    const roots = resolveMemoryRoots(dir, {});
+    assert.deepStrictEqual(roots, [dir]);
+  } finally {
+    teardown();
+  }
+};
+
+exports.test_resolveMemoryRoots_supports_global_scope = () => {
+  setup();
+  try {
+    const roots = resolveMemoryRoots(dir, { scope: 'global' });
+    assert.deepStrictEqual(roots, [os.homedir()]);
+  } finally {
+    teardown();
+  }
+};
+
+exports.test_resolveMemoryRoots_supports_all_scope = () => {
+  setup();
+  try {
+    const roots = resolveMemoryRoots(dir, { scope: 'all' });
+    assert.deepStrictEqual(roots, [dir, os.homedir()]);
+  } finally {
+    teardown();
+  }
+};


### PR DESCRIPTION
## Summary

Refine MCP/search performance and add local-first scoped memory recall. This keeps repo memory as the default while adding explicit global personal memory, SQLite-backed indexing, and a reindex command for faster search paths.

## What changed

- added repo/global/all memory scope resolution and CLI flags for `log`, `memory`, and `ask`
- added global personal memory storage under `~/.mindswap/` with scoped CRUD and scoped ask/search recall
- added a local SQLite index store plus `mindswap reindex --scope repo|global|all`
- made MCP `mindswap_search` prefer indexed results when `.mindswap/mindswap.db` exists, with file-based fallback
- documented the local-first roadmap and global memory implementation plan
- added regression tests for scoped memory, global recall, reindexing, indexed search, and MCP index preference

## Validation

- `npm test` -> `180 passed, 0 failed`

## Notes

Sandboxed `npm test` cannot bind the local HTTP test server on `127.0.0.1`, so validation was rerun outside the sandbox with the approved test command.